### PR TITLE
Allow recording software to capture audio

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.unity3d.player"
     xmlns:tools="http://schemas.android.com/tools">
-    <application>
+    <application android:allowAudioPlaybackCapture="true">
     <!--<application android:requestLegacyExternalStorage="true">-->
 
         <activity android:name="me.tigerhix.cytoid.CytoidPluginActivity"


### PR DESCRIPTION
As per https://developer.android.com/guide/topics/media/playback-capture, this allows cytoid's audio to be recorded by other apps on the device. This is useful both for people who want to quickly record gameplay, and people using tools such as sndcpy to mirror their device's audio. I have not tested a full build (as I lack the required unity plugins) however I have patched this change into a production build with success.