### PR TITLE
fix(gameplay): share visuals for co-located drag-child stacks

### DIFF
--- a/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs
+++ b/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs
@@ -40,6 +40,20 @@ public class DragStackPlannerTests
     }
 
     [Test]
+    public void DifferentIntroTimesDoNotStack()
+    {
+        var a = Child(1, 0.5, 1f);
+        var b = Child(2, 0.5, 1f);
+        a.intro_time = 0.1f;
+        b.intro_time = 0.4f;
+        var model = Model(a, b);
+
+        var plan = DragStackPlanner.Build(model);
+
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+    }
+
+    [Test]
     public void DifferentVisualFieldsDoNotStack()
     {
         var a = Child(1, 0.5, 1f);

--- a/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs
+++ b/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs
@@ -1,0 +1,224 @@
+using System.Collections.Generic;
+using Cytoid.Storyboard;
+using NUnit.Framework;
+
+public class DragStackPlannerTests
+{
+    [Test]
+    public void CoLocatedDragChildrenShareAStack()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f, next: 3),
+            Child(2, 0.5, 1f, next: 4),
+            Child(3, 0.5, 2f),
+            Child(4, 0.5, 2f));
+
+        var plan = DragStackPlanner.Build(model);
+
+        Assert.That(plan.NoteIdToStackId.Count, Is.EqualTo(4));
+        Assert.That(plan.NoteIdToStackId[1], Is.EqualTo(plan.NoteIdToStackId[2]));
+        Assert.That(plan.NoteIdToStackId[3], Is.EqualTo(plan.NoteIdToStackId[4]));
+        Assert.That(plan.NoteIdToStackId[1], Is.Not.EqualTo(plan.NoteIdToStackId[3]));
+        Assert.That(plan.MaxSamePageDragStackHostCount, Is.EqualTo(2));
+        Assert.That(plan.MaxSamePageDragLineCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void DragHeadsAreNeverStacked()
+    {
+        var model = Model(
+            Head(1, 0.5, 1f, next: 3),
+            Head(2, 0.5, 1f, next: 4),
+            Child(3, 0.5, 2f),
+            Child(4, 0.5, 2f));
+
+        var plan = DragStackPlanner.Build(model);
+
+        Assert.That(plan.NoteIdToStackId.ContainsKey(1), Is.False);
+        Assert.That(plan.NoteIdToStackId.ContainsKey(2), Is.False);
+        Assert.That(plan.NoteIdToStackId[3], Is.EqualTo(plan.NoteIdToStackId[4]));
+    }
+
+    [Test]
+    public void DifferentVisualFieldsDoNotStack()
+    {
+        var a = Child(1, 0.5, 1f);
+        var b = Child(2, 0.5, 1f);
+        b.size = 2.0;
+        var model = Model(a, b);
+
+        var plan = DragStackPlanner.Build(model);
+
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+    }
+
+    [Test]
+    public void IndependentStoryboardSignaturesDoNotStack()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f),
+            Child(2, 0.5, 1f));
+        var signatures = new Dictionary<int, string>
+        {
+            {1, "x=0.2"},
+            {2, "x=0.8"}
+        };
+
+        var plan = DragStackPlanner.Build(model, signatures);
+
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+    }
+
+    [Test]
+    public void ControlledNoteDoesNotStackWithUncontrolledSibling()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f),
+            Child(2, 0.5, 1f));
+        var signatures = new Dictionary<int, string>
+        {
+            {1, "x=0.2"}
+        };
+
+        var plan = DragStackPlanner.Build(model, signatures);
+
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+    }
+
+    [Test]
+    public void IdenticalStoryboardSignaturesStillStack()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f),
+            Child(2, 0.5, 1f));
+        var signatures = new Dictionary<int, string>
+        {
+            {1, "dx=0.1"},
+            {2, "dx=0.1"}
+        };
+
+        var plan = DragStackPlanner.Build(model, signatures);
+
+        Assert.That(plan.NoteIdToStackId[1], Is.EqualTo(plan.NoteIdToStackId[2]));
+    }
+
+    [Test]
+    public void TriggerSpawnedControllersNeverShareAStack()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f),
+            Child(2, 0.5, 1f));
+        var signatures = new Dictionary<int, string>
+        {
+            {1, DragStackPlanner.TriggerSignaturePrefix + 1},
+            {2, DragStackPlanner.TriggerSignaturePrefix + 2}
+        };
+
+        var plan = DragStackPlanner.Build(model, signatures);
+
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+    }
+
+    [Test]
+    public void DivergentNextNotesRefuseASharedStack()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f, next: 3),
+            Child(2, 0.5, 1f, next: 4),
+            Child(3, 0.2, 2f),
+            Child(4, 0.8, 2f));
+
+        var plan = DragStackPlanner.Build(model);
+        var keyA = DragStackPlanner.MakeDragLineShareKey(
+            model.note_map[1], model.note_map[3], plan.NoteIdToStackId);
+        var keyB = DragStackPlanner.MakeDragLineShareKey(
+            model.note_map[2], model.note_map[4], plan.NoteIdToStackId);
+
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+        Assert.That(keyA, Is.Not.EqualTo(keyB));
+        Assert.That(plan.MaxSamePageDragLineCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void UniformNoteControllersProduceMatchingSignatures()
+    {
+        var shared = Controller("same", 1, 0.1f);
+        var copy = Controller("same-copy", 2, 0.1f);
+        var signatures = DragStackPlanner.SignaturesFromNoteControllers(new[] {shared, copy});
+
+        Assert.That(signatures[1], Is.EqualTo(signatures[2]));
+        Assert.That(signatures[1].StartsWith(DragStackPlanner.TriggerSignaturePrefix), Is.False);
+    }
+
+    [Test]
+    public void TriggerNoteControllersProduceUniqueSignatures()
+    {
+        var a = Controller("trig-a", 1, 0.1f);
+        a.States[0].Time = float.MaxValue;
+        var b = Controller("trig-b", 2, 0.1f);
+        b.States[0].Time = float.MaxValue;
+
+        var signatures = DragStackPlanner.SignaturesFromNoteControllers(new[] {a, b});
+
+        Assert.That(signatures[1], Is.EqualTo(DragStackPlanner.TriggerSignaturePrefix + 1));
+        Assert.That(signatures[2], Is.EqualTo(DragStackPlanner.TriggerSignaturePrefix + 2));
+        Assert.That(signatures[1], Is.Not.EqualTo(signatures[2]));
+    }
+
+    static ChartModel Model(params ChartModel.Note[] notes)
+    {
+        var model = new ChartModel
+        {
+            page_list = new List<ChartModel.Page> {new ChartModel.Page()}
+        };
+        foreach (var note in notes)
+        {
+            model.note_list.Add(note);
+            model.note_map[note.id] = note;
+        }
+
+        return model;
+    }
+
+    static ChartModel.Note Head(int id, double x, float startTime, int next = -1)
+    {
+        return Note(id, NoteType.DragHead, x, startTime, next);
+    }
+
+    static ChartModel.Note Child(int id, double x, float startTime, int next = -1)
+    {
+        return Note(id, NoteType.DragChild, x, startTime, next);
+    }
+
+    static ChartModel.Note Note(int id, NoteType type, double x, float startTime, int next)
+    {
+        return new ChartModel.Note
+        {
+            id = id,
+            type = (int) type,
+            page_index = 0,
+            x = x,
+            start_time = startTime,
+            next_id = next,
+            approach_rate = 1.0,
+            style = 1
+        };
+    }
+
+    static NoteController Controller(string id, int noteId, float xOffset)
+    {
+        return new NoteController
+        {
+            Id = id,
+            States = new List<NoteControllerState>
+            {
+                new NoteControllerState
+                {
+                    Time = 0,
+                    Note = noteId,
+                    XOffset = xOffset
+                }
+            }
+        };
+    }
+}

--- a/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b00e57896cc048f4a434b3805142cfcc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -35,7 +35,7 @@ public class Chart
     /// <summary>stack id → note ids sorted ascending (list-order / DragCoHit order).</summary>
     public Dictionary<int, List<int>> DragStackMembers { get; } = new Dictionary<int, List<int>>();
 
-    /// <summary>Peak distinct drag-stack hosts on one page (for pool sizing).</summary>
+    /// <summary>Peak distinct drag-stack hosts on one page (ClearDrag pool floor after stacking).</summary>
     public int MaxSamePageDragStackHostCount { get; private set; }
 
     /// <summary>

--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -37,6 +37,12 @@ public class Chart
 
     /// <summary>Peak distinct drag-stack hosts on one page (for pool sizing).</summary>
     public int MaxSamePageDragStackHostCount { get; private set; }
+
+    /// <summary>
+    /// Peak distinct drag-line GOs on one page after stack sharing.
+    /// Counts unshared edges plus one line per unique stacked endpoint pair.
+    /// </summary>
+    public int MaxSamePageDragLineCount { get; private set; }
     
     private readonly float baseSize;
     private readonly float horizontalRatio;
@@ -261,70 +267,30 @@ public class Chart
                     note.tint = note.direction == 1 ? 1.00f : 1.30f;
                     break;
             }
-
-        BuildDragStacks();
     }
 
     /// <summary>
-    /// Groups co-located drag notes that share type, start time, and chart x into stacks.
-    /// Only multi-member groups are recorded — singles keep the legacy per-note path.
+    /// Groups co-located drag children after storyboard parse. Call once from
+    /// <see cref="Game.Initialize"/> so note-controller signatures are already resolved.
+    /// Charts without storyboard pass a null signature map (uncontrolled notes only).
     /// </summary>
-    private void BuildDragStacks()
+    public void ApplyDragStacks(IReadOnlyDictionary<int, string> storyboardSignatures = null)
     {
+        var plan = DragStackPlanner.Build(Model, storyboardSignatures);
         NoteIdToDragStackId.Clear();
+        foreach (var pair in plan.NoteIdToStackId)
+        {
+            NoteIdToDragStackId[pair.Key] = pair.Value;
+        }
+
         DragStackMembers.Clear();
-
-        var buckets = new Dictionary<long, List<int>>();
-        foreach (var note in Model.note_list)
+        foreach (var pair in plan.StackMembers)
         {
-            var type = (NoteType) note.type;
-            // CDragHead is Select-consumed (one per Down); do not stack-share its collider.
-            if (type != NoteType.DragHead && type != NoteType.DragChild &&
-                type != NoteType.CDragChild)
-            {
-                continue;
-            }
-
-            var key = MakeDragStackKey(type, note.start_time, note.x);
-            if (!buckets.TryGetValue(key, out var list))
-            {
-                list = new List<int>();
-                buckets[key] = list;
-            }
-
-            list.Add(note.id);
+            DragStackMembers[pair.Key] = pair.Value;
         }
 
-        var nextStackId = 1;
-        var pageHostCounts = new int[Model.page_list.Count];
-        foreach (var pair in buckets)
-        {
-            var ids = pair.Value;
-            if (ids.Count < 2) continue;
-
-            ids.Sort();
-            var stackId = nextStackId++;
-            DragStackMembers[stackId] = ids;
-            var pageIndex = Model.note_map[ids[0]].page_index;
-            if (pageIndex >= 0 && pageIndex < pageHostCounts.Length)
-            {
-                pageHostCounts[pageIndex]++;
-            }
-
-            foreach (var id in ids)
-            {
-                NoteIdToDragStackId[id] = stackId;
-            }
-        }
-
-        MaxSamePageDragStackHostCount = pageHostCounts.Length > 0 ? pageHostCounts.Max() : 0;
-    }
-
-    private static long MakeDragStackKey(NoteType type, float startTime, double x)
-    {
-        var t = (long) Mathf.Round(startTime * 1000f);
-        var xq = (long) Mathf.Round((float) x * 10000f);
-        return ((long) (int) type << 48) ^ (t << 20) ^ (xq & 0xFFFFF);
+        MaxSamePageDragStackHostCount = plan.MaxSamePageDragStackHostCount;
+        MaxSamePageDragLineCount = plan.MaxSamePageDragLineCount;
     }
 
     private float ConvertToTime(float tick)

--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -28,6 +28,15 @@ public class Chart
     public int MaxSamePageNonDragTypeNoteCount { get; }
     public int MaxSamePageDragTypeNoteCount { get; }
     public int MaxSamePageHoldTypeNoteCount { get; }
+
+    /// <summary>note id → drag stack id (only multi-note stacks, size ≥ 2).</summary>
+    public Dictionary<int, int> NoteIdToDragStackId { get; } = new Dictionary<int, int>();
+
+    /// <summary>stack id → note ids sorted ascending (list-order / DragCoHit order).</summary>
+    public Dictionary<int, List<int>> DragStackMembers { get; } = new Dictionary<int, List<int>>();
+
+    /// <summary>Peak distinct drag-stack hosts on one page (for pool sizing).</summary>
+    public int MaxSamePageDragStackHostCount { get; private set; }
     
     private readonly float baseSize;
     private readonly float horizontalRatio;
@@ -252,6 +261,70 @@ public class Chart
                     note.tint = note.direction == 1 ? 1.00f : 1.30f;
                     break;
             }
+
+        BuildDragStacks();
+    }
+
+    /// <summary>
+    /// Groups co-located drag notes that share type, start time, and chart x into stacks.
+    /// Only multi-member groups are recorded — singles keep the legacy per-note path.
+    /// </summary>
+    private void BuildDragStacks()
+    {
+        NoteIdToDragStackId.Clear();
+        DragStackMembers.Clear();
+
+        var buckets = new Dictionary<long, List<int>>();
+        foreach (var note in Model.note_list)
+        {
+            var type = (NoteType) note.type;
+            // CDragHead is Select-consumed (one per Down); do not stack-share its collider.
+            if (type != NoteType.DragHead && type != NoteType.DragChild &&
+                type != NoteType.CDragChild)
+            {
+                continue;
+            }
+
+            var key = MakeDragStackKey(type, note.start_time, note.x);
+            if (!buckets.TryGetValue(key, out var list))
+            {
+                list = new List<int>();
+                buckets[key] = list;
+            }
+
+            list.Add(note.id);
+        }
+
+        var nextStackId = 1;
+        var pageHostCounts = new int[Model.page_list.Count];
+        foreach (var pair in buckets)
+        {
+            var ids = pair.Value;
+            if (ids.Count < 2) continue;
+
+            ids.Sort();
+            var stackId = nextStackId++;
+            DragStackMembers[stackId] = ids;
+            var pageIndex = Model.note_map[ids[0]].page_index;
+            if (pageIndex >= 0 && pageIndex < pageHostCounts.Length)
+            {
+                pageHostCounts[pageIndex]++;
+            }
+
+            foreach (var id in ids)
+            {
+                NoteIdToDragStackId[id] = stackId;
+            }
+        }
+
+        MaxSamePageDragStackHostCount = pageHostCounts.Length > 0 ? pageHostCounts.Max() : 0;
+    }
+
+    private static long MakeDragStackKey(NoteType type, float startTime, double x)
+    {
+        var t = (long) Mathf.Round(startTime * 1000f);
+        var xq = (long) Mathf.Round((float) x * 10000f);
+        return ((long) (int) type << 48) ^ (t << 20) ^ (xq & 0xFFFFF);
     }
 
     private float ConvertToTime(float tick)

--- a/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs
@@ -10,7 +10,7 @@ using Cytoid.Storyboard;
 /// <list type="number">
 /// <item>Type is <see cref="NoteType.DragChild"/> or <see cref="NoteType.CDragChild"/>.
 /// Heads travel along their own chain and cannot share a host.</item>
-/// <item>Full visual/collision equivalence: type, start time, chart x, approach rate,
+/// <item>Full visual/collision equivalence: type, start time, intro time, chart x, approach rate,
 /// size, opacity, hitbox, colors, style, page index, scan direction, and is_forward.</item>
 /// <item>Storyboard note-controller signature matches. Signatures are computed from
 /// the parsed storyboard so selector expansion and <c>$note</c> substitution are
@@ -379,6 +379,7 @@ public static class DragStackPlanner
     {
         public readonly NoteType Type;
         public readonly int StartTimeMs;
+        public readonly int IntroTimeMs;
         public readonly int Xq;
         public readonly int ApproachRateQ;
         public readonly int SizeQ;
@@ -395,6 +396,7 @@ public static class DragStackPlanner
         EquivalenceKey(
             NoteType type,
             int startTimeMs,
+            int introTimeMs,
             int xq,
             int approachRateQ,
             int sizeQ,
@@ -410,6 +412,7 @@ public static class DragStackPlanner
         {
             Type = type;
             StartTimeMs = startTimeMs;
+            IntroTimeMs = introTimeMs;
             Xq = xq;
             ApproachRateQ = approachRateQ;
             SizeQ = sizeQ;
@@ -429,6 +432,7 @@ public static class DragStackPlanner
             return new EquivalenceKey(
                 (NoteType) note.type,
                 (int) Math.Round(note.start_time * 1000.0),
+                (int) Math.Round(note.intro_time * 1000.0),
                 (int) Math.Round(note.x * 10000.0),
                 Quantize(note.approach_rate),
                 Quantize(note.size),
@@ -453,6 +457,7 @@ public static class DragStackPlanner
         {
             return Type == other.Type &&
                    StartTimeMs == other.StartTimeMs &&
+                   IntroTimeMs == other.IntroTimeMs &&
                    Xq == other.Xq &&
                    ApproachRateQ == other.ApproachRateQ &&
                    SizeQ == other.SizeQ &&
@@ -475,6 +480,7 @@ public static class DragStackPlanner
             {
                 var hash = (int) Type;
                 hash = (hash * 397) ^ StartTimeMs;
+                hash = (hash * 397) ^ IntroTimeMs;
                 hash = (hash * 397) ^ Xq;
                 hash = (hash * 397) ^ ApproachRateQ;
                 hash = (hash * 397) ^ SizeQ;

--- a/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs
@@ -1,0 +1,494 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Cytoid.Storyboard;
+
+/// <summary>
+/// Builds visual/collider drag stacks after chart load and storyboard parse.
+///
+/// Eligibility (all must hold; otherwise the note keeps the per-note path):
+/// <list type="number">
+/// <item>Type is <see cref="NoteType.DragChild"/> or <see cref="NoteType.CDragChild"/>.
+/// Heads travel along their own chain and cannot share a host.</item>
+/// <item>Full visual/collision equivalence: type, start time, chart x, approach rate,
+/// size, opacity, hitbox, colors, style, page index, scan direction, and is_forward.</item>
+/// <item>Storyboard note-controller signature matches. Signatures are computed from
+/// the parsed storyboard so selector expansion and <c>$note</c> substitution are
+/// already resolved. Empty signature = uncontrolled. Trigger-spawned controllers
+/// (unknown timeline until fire) force a unique per-note signature so they never merge.</item>
+/// <item>Outgoing chain destinations match: every member has no next, or every next
+/// note shares the same visual/storyboard key. Origins whose next notes diverge
+/// stay independent so shared rotation cannot point a line at the wrong child.</item>
+/// <item>At least two notes share the same key.</item>
+/// </list>
+/// Drag-line sharing uses stack identity of both endpoints, not static chart x/time,
+/// so independently storyboard-moved endpoints never share a line.
+/// </summary>
+public sealed class DragStackPlan
+{
+    public Dictionary<int, int> NoteIdToStackId { get; } = new Dictionary<int, int>();
+    public Dictionary<int, List<int>> StackMembers { get; } = new Dictionary<int, List<int>>();
+    public int MaxSamePageDragStackHostCount { get; set; }
+    public int MaxSamePageDragLineCount { get; set; }
+}
+
+public static class DragStackPlanner
+{
+    public const string UncontrolledSignature = "";
+    public const string TriggerSignaturePrefix = "trigger:";
+
+    public static DragStackPlan Build(
+        ChartModel model,
+        IReadOnlyDictionary<int, string> storyboardSignatures = null)
+    {
+        var plan = new DragStackPlan();
+        if (model?.note_list == null || model.note_list.Count == 0) return plan;
+
+        var pageCount = model.page_list != null ? model.page_list.Count : 0;
+        var buckets = new Dictionary<EquivalenceKey, List<int>>();
+
+        foreach (var note in model.note_list)
+        {
+            if (note == null) continue;
+            var type = (NoteType) note.type;
+            if (type != NoteType.DragChild && type != NoteType.CDragChild) continue;
+
+            string signature;
+            if (storyboardSignatures == null ||
+                !storyboardSignatures.TryGetValue(note.id, out signature) ||
+                signature == null)
+            {
+                signature = UncontrolledSignature;
+            }
+
+            var key = EquivalenceKey.From(note, signature);
+            if (!buckets.TryGetValue(key, out var list))
+            {
+                list = new List<int>();
+                buckets[key] = list;
+            }
+
+            list.Add(note.id);
+        }
+
+        var nextStackId = 1;
+        var pageHostCounts = pageCount > 0 ? new int[pageCount] : Array.Empty<int>();
+        foreach (var pair in buckets)
+        {
+            var ids = pair.Value;
+            if (ids.Count < 2) continue;
+            if (!NextDestinationsMatch(ids, model, storyboardSignatures)) continue;
+
+            ids.Sort();
+            var stackId = nextStackId++;
+            plan.StackMembers[stackId] = ids;
+            var first = model.note_map != null && model.note_map.TryGetValue(ids[0], out var firstNote)
+                ? firstNote
+                : FindNote(model, ids[0]);
+            var pageIndex = first != null ? first.page_index : 0;
+            if (pageIndex >= 0 && pageIndex < pageHostCounts.Length)
+            {
+                pageHostCounts[pageIndex]++;
+            }
+
+            foreach (var id in ids)
+            {
+                plan.NoteIdToStackId[id] = stackId;
+            }
+        }
+
+        plan.MaxSamePageDragStackHostCount = pageHostCounts.Length > 0 ? Max(pageHostCounts) : 0;
+        plan.MaxSamePageDragLineCount = CountMaxSamePageDragLines(model, plan.NoteIdToStackId, pageCount);
+        return plan;
+    }
+
+    /// <summary>
+    /// Share key for coincident drag-line geometry. Uses stack ids when both
+    /// endpoints are stacked; otherwise the concrete note id so storyboard-divergent
+    /// endpoints never collapse onto one <see cref="DragLineElement"/>.
+    /// </summary>
+    public static long MakeDragLineShareKey(
+        ChartModel.Note from,
+        ChartModel.Note to,
+        IReadOnlyDictionary<int, int> noteIdToStackId)
+    {
+        if (from == null || to == null) return 0;
+        unchecked
+        {
+            long hash = 17;
+            hash = hash * 31 + from.type;
+            hash = hash * 31 + to.type;
+            hash = hash * 31 + EndpointIdentity(from.id, noteIdToStackId);
+            hash = hash * 31 + EndpointIdentity(to.id, noteIdToStackId);
+            return hash;
+        }
+    }
+
+    public static Dictionary<int, string> SignaturesFromNoteControllers(
+        IEnumerable<NoteController> controllers)
+    {
+        var result = new Dictionary<int, string>();
+        if (controllers == null) return result;
+
+        var byNote = new Dictionary<int, List<NoteController>>();
+        foreach (var controller in controllers)
+        {
+            if (controller == null) continue;
+            var noteId = ResolveNoteId(controller);
+            if (noteId == null) continue;
+            if (!byNote.TryGetValue(noteId.Value, out var list))
+            {
+                list = new List<NoteController>();
+                byNote[noteId.Value] = list;
+            }
+
+            list.Add(controller);
+        }
+
+        foreach (var pair in byNote)
+        {
+            var noteId = pair.Key;
+            var list = pair.Value;
+            var triggerControlled = false;
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (list[i].IsManuallySpawned())
+                {
+                    triggerControlled = true;
+                    break;
+                }
+            }
+
+            if (triggerControlled)
+            {
+                result[noteId] = TriggerSignaturePrefix + noteId;
+                continue;
+            }
+
+            list.Sort((a, b) => string.CompareOrdinal(a.Id, b.Id));
+            var builder = new StringBuilder();
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (i > 0) builder.Append("||");
+                AppendControllerFingerprint(builder, list[i]);
+            }
+
+            result[noteId] = builder.ToString();
+        }
+
+        return result;
+    }
+
+    static int EndpointIdentity(int noteId, IReadOnlyDictionary<int, int> noteIdToStackId)
+    {
+        if (noteIdToStackId != null && noteIdToStackId.TryGetValue(noteId, out var stackId) && stackId > 0)
+        {
+            return stackId;
+        }
+
+        // Unstacked notes keep a distinct identity in the negative range.
+        return -noteId - 1;
+    }
+
+    static int CountMaxSamePageDragLines(
+        ChartModel model,
+        IReadOnlyDictionary<int, int> noteIdToStackId,
+        int pageCount)
+    {
+        if (pageCount <= 0) return 0;
+        var perPage = new HashSet<long>[pageCount];
+        for (var i = 0; i < pageCount; i++) perPage[i] = new HashSet<long>();
+
+        foreach (var note in model.note_list)
+        {
+            if (note == null || note.next_id <= 0) continue;
+            var type = (NoteType) note.type;
+            if (type != NoteType.DragHead && type != NoteType.DragChild &&
+                type != NoteType.CDragHead && type != NoteType.CDragChild)
+            {
+                continue;
+            }
+
+            if (model.note_map == null || !model.note_map.TryGetValue(note.next_id, out var to) || to == null)
+            {
+                continue;
+            }
+
+            var pageIndex = note.page_index;
+            if (pageIndex < 0 || pageIndex >= pageCount) continue;
+            perPage[pageIndex].Add(MakeDragLineShareKey(note, to, noteIdToStackId));
+        }
+
+        var max = 0;
+        for (var i = 0; i < pageCount; i++)
+        {
+            if (perPage[i].Count > max) max = perPage[i].Count;
+        }
+
+        return max;
+    }
+
+    static bool NextDestinationsMatch(
+        List<int> ids,
+        ChartModel model,
+        IReadOnlyDictionary<int, string> storyboardSignatures)
+    {
+        var haveFirst = false;
+        var firstIsNone = false;
+        var firstKey = default(EquivalenceKey);
+
+        for (var i = 0; i < ids.Count; i++)
+        {
+            var note = LookupNote(model, ids[i]);
+            ChartModel.Note next = null;
+            var isNone = note == null || note.next_id <= 0 ||
+                         (next = LookupNote(model, note.next_id)) == null;
+
+            if (!haveFirst)
+            {
+                firstIsNone = isNone;
+                if (!isNone) firstKey = EquivalenceKey.From(next, SignatureOf(next.id, storyboardSignatures));
+                haveFirst = true;
+                continue;
+            }
+
+            if (isNone != firstIsNone) return false;
+            if (isNone) continue;
+            if (!firstKey.Equals(EquivalenceKey.From(next, SignatureOf(next.id, storyboardSignatures))))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static string SignatureOf(int noteId, IReadOnlyDictionary<int, string> storyboardSignatures)
+    {
+        if (storyboardSignatures == null ||
+            !storyboardSignatures.TryGetValue(noteId, out var signature) ||
+            signature == null)
+        {
+            return UncontrolledSignature;
+        }
+
+        return signature;
+    }
+
+    static ChartModel.Note LookupNote(ChartModel model, int id)
+    {
+        if (model.note_map != null && model.note_map.TryGetValue(id, out var mapped) && mapped != null)
+        {
+            return mapped;
+        }
+
+        return FindNote(model, id);
+    }
+
+    static ChartModel.Note FindNote(ChartModel model, int id)
+    {
+        for (var i = 0; i < model.note_list.Count; i++)
+        {
+            if (model.note_list[i] != null && model.note_list[i].id == id) return model.note_list[i];
+        }
+
+        return null;
+    }
+
+    static int Max(int[] values)
+    {
+        var max = 0;
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i] > max) max = values[i];
+        }
+
+        return max;
+    }
+
+    static int? ResolveNoteId(NoteController controller)
+    {
+        if (controller.States == null) return null;
+        for (var i = 0; i < controller.States.Count; i++)
+        {
+            var note = controller.States[i]?.Note;
+            if (note != null) return note;
+        }
+
+        return null;
+    }
+
+    static void AppendControllerFingerprint(StringBuilder builder, NoteController controller)
+    {
+        var states = controller.States;
+        if (states == null) return;
+        for (var i = 0; i < states.Count; i++)
+        {
+            if (i > 0) builder.Append(';');
+            AppendStateFingerprint(builder, states[i]);
+        }
+    }
+
+    static void AppendStateFingerprint(StringBuilder builder, NoteControllerState state)
+    {
+        if (state == null)
+        {
+            builder.Append("null");
+            return;
+        }
+
+        builder.Append(state.Time.ToString("R"));
+        builder.Append('|').Append(Flag(state.OverrideX)).Append(Unit(state.X));
+        builder.Append('|').Append(Num(state.XMultiplier)).Append(',').Append(Num(state.XOffset));
+        builder.Append('|').Append(Flag(state.OverrideY)).Append(Unit(state.Y));
+        builder.Append('|').Append(Num(state.YMultiplier)).Append(',').Append(Num(state.YOffset));
+        builder.Append('|').Append(Flag(state.OverrideZ)).Append(Unit(state.Z));
+        builder.Append('|').Append(Flag(state.OverrideRotX)).Append(Num(state.RotX));
+        builder.Append('|').Append(Flag(state.OverrideRotY)).Append(Num(state.RotY));
+        builder.Append('|').Append(Flag(state.OverrideRotZ)).Append(Num(state.RotZ));
+        builder.Append('|').Append(Flag(state.OverrideRingColor)).Append(Color(state.RingColor));
+        builder.Append('|').Append(Flag(state.OverrideFillColor)).Append(Color(state.FillColor));
+        builder.Append('|').Append(Num(state.OpacityMultiplier));
+        builder.Append('|').Append(Num(state.SizeMultiplier));
+        builder.Append('|').Append(Num(state.HitboxMultiplier));
+        builder.Append('|').Append(state.HoldDirection);
+        builder.Append('|').Append(state.Style);
+        builder.Append('|').Append(state.Easing);
+        builder.Append('|').Append(Flag(state.Destroy));
+    }
+
+    static string Flag(bool? value) => value == null ? "_" : (value.Value ? "1" : "0");
+
+    static string Num(float? value) => value == null ? "_" : value.Value.ToString("R");
+
+    static string Unit(UnitFloat value)
+    {
+        if (value == null) return "_";
+        return value.Value.ToString("R") + ":" + (int) value.Unit + ":" + (value.ScaleToCanvas ? 1 : 0) + ":" +
+               (value.Span ? 1 : 0);
+    }
+
+    static string Color(Cytoid.Storyboard.Color value)
+    {
+        if (value == null) return "_";
+        return value.R.ToString("R") + "," + value.G.ToString("R") + "," + value.B.ToString("R") + "," +
+               value.A.ToString("R");
+    }
+
+    readonly struct EquivalenceKey : IEquatable<EquivalenceKey>
+    {
+        public readonly NoteType Type;
+        public readonly int StartTimeMs;
+        public readonly int Xq;
+        public readonly int ApproachRateQ;
+        public readonly int SizeQ;
+        public readonly int OpacityQ;
+        public readonly int HitboxQ;
+        public readonly int Style;
+        public readonly int Direction;
+        public readonly int PageIndex;
+        public readonly bool IsForward;
+        public readonly string RingColor;
+        public readonly string FillColor;
+        public readonly string StoryboardSignature;
+
+        EquivalenceKey(
+            NoteType type,
+            int startTimeMs,
+            int xq,
+            int approachRateQ,
+            int sizeQ,
+            int opacityQ,
+            int hitboxQ,
+            int style,
+            int direction,
+            int pageIndex,
+            bool isForward,
+            string ringColor,
+            string fillColor,
+            string storyboardSignature)
+        {
+            Type = type;
+            StartTimeMs = startTimeMs;
+            Xq = xq;
+            ApproachRateQ = approachRateQ;
+            SizeQ = sizeQ;
+            OpacityQ = opacityQ;
+            HitboxQ = hitboxQ;
+            Style = style;
+            Direction = direction;
+            PageIndex = pageIndex;
+            IsForward = isForward;
+            RingColor = ringColor ?? "";
+            FillColor = fillColor ?? "";
+            StoryboardSignature = storyboardSignature ?? UncontrolledSignature;
+        }
+
+        public static EquivalenceKey From(ChartModel.Note note, string signature)
+        {
+            return new EquivalenceKey(
+                (NoteType) note.type,
+                (int) Math.Round(note.start_time * 1000.0),
+                (int) Math.Round(note.x * 10000.0),
+                Quantize(note.approach_rate),
+                Quantize(note.size),
+                Quantize(note.opacity),
+                Quantize(note.hitbox),
+                note.style,
+                note.direction,
+                note.page_index,
+                note.is_forward,
+                note.ring_color,
+                note.fill_color,
+                signature);
+        }
+
+        static int Quantize(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value)) return int.MinValue;
+            return (int) Math.Round(value * 10000.0);
+        }
+
+        public bool Equals(EquivalenceKey other)
+        {
+            return Type == other.Type &&
+                   StartTimeMs == other.StartTimeMs &&
+                   Xq == other.Xq &&
+                   ApproachRateQ == other.ApproachRateQ &&
+                   SizeQ == other.SizeQ &&
+                   OpacityQ == other.OpacityQ &&
+                   HitboxQ == other.HitboxQ &&
+                   Style == other.Style &&
+                   Direction == other.Direction &&
+                   PageIndex == other.PageIndex &&
+                   IsForward == other.IsForward &&
+                   RingColor == other.RingColor &&
+                   FillColor == other.FillColor &&
+                   StoryboardSignature == other.StoryboardSignature;
+        }
+
+        public override bool Equals(object obj) => obj is EquivalenceKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = (int) Type;
+                hash = (hash * 397) ^ StartTimeMs;
+                hash = (hash * 397) ^ Xq;
+                hash = (hash * 397) ^ ApproachRateQ;
+                hash = (hash * 397) ^ SizeQ;
+                hash = (hash * 397) ^ OpacityQ;
+                hash = (hash * 397) ^ HitboxQ;
+                hash = (hash * 397) ^ Style;
+                hash = (hash * 397) ^ Direction;
+                hash = (hash * 397) ^ PageIndex;
+                hash = (hash * 397) ^ (IsForward ? 1 : 0);
+                hash = (hash * 397) ^ (RingColor != null ? RingColor.GetHashCode() : 0);
+                hash = (hash * 397) ^ (FillColor != null ? FillColor.GetHashCode() : 0);
+                hash = (hash * 397) ^ (StoryboardSignature != null ? StoryboardSignature.GetHashCode() : 0);
+                return hash;
+            }
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51901ec7a8c84237bcd8638a659c02ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -262,6 +262,7 @@ public class Game : MonoBehaviour
         // Load storyboard
         var storyboardText = await contentProvider.LoadStoryboardText();
         StoryboardPath = contentProvider.IsExternal ? null : Level.Path + (chartMeta.storyboard?.path ?? "storyboard.json");
+        var storyboardReady = false;
         if (!string.IsNullOrEmpty(storyboardText))
         {
             Debug.Log($"[CYTOID-DBG] Game.Initialize: loading storyboard (text length={storyboardText.Length})");
@@ -271,6 +272,7 @@ public class Game : MonoBehaviour
                 Storyboard = new Cytoid.Storyboard.Storyboard(this, storyboardText);
                 Storyboard.Parse();
                 await Storyboard.Initialize();
+                storyboardReady = true;
                 Debug.Log("[CYTOID-DBG] Game.Initialize: storyboard loaded OK");
                 print(contentProvider.IsExternal ? "Loaded storyboard from external payload" : $"Loaded storyboard from {StoryboardPath}");
             }
@@ -289,9 +291,9 @@ public class Game : MonoBehaviour
             Debug.Log("[CYTOID-DBG] Game.Initialize: storyboard text empty/null — skipping");
         }
 
-        // Drag-stack merge runs after storyboard parse so note controllers (including
-        // selector expansion and $note substitution) can refuse independently-moved chains.
-        Chart.ApplyDragStacks(Storyboard != null
+        // Drag-stack merge runs after a successful storyboard load only. A failed or
+        // partial Parse/Initialize must not feed NoteControllers into the planner.
+        Chart.ApplyDragStacks(storyboardReady
             ? DragStackPlanner.SignaturesFromNoteControllers(Storyboard.NoteControllers.Values)
             : null);
 

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -289,6 +289,12 @@ public class Game : MonoBehaviour
             Debug.Log("[CYTOID-DBG] Game.Initialize: storyboard text empty/null — skipping");
         }
 
+        // Drag-stack merge runs after storyboard parse so note controllers (including
+        // selector expansion and $note substitution) can refuse independently-moved chains.
+        Chart.ApplyDragStacks(Storyboard != null
+            ? DragStackPlanner.SignaturesFromNoteControllers(Storyboard.NoteControllers.Values)
+            : null);
+
         // Load hit sound
         if (Context.Player.Settings.HitSound != "none")
         {

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -131,6 +131,8 @@ public class InputController : MonoBehaviour
 
             if (note.Type == NoteType.DragHead || note.Type == NoteType.DragChild || note.Type == NoteType.CDragChild || note.Type == NoteType.DropDrag)
             {
+                // Stack followers share the primary collider ? only scan primaries here.
+                if (note.IsDragStackFollower) continue;
                 TouchableDragNotes.Add(note);
                 continue;
             }
@@ -144,6 +146,7 @@ public class InputController : MonoBehaviour
                 continue;
             }
 
+            // CDragHead stays on the normal Select path (not stack-collapsed).
             TouchableSelectNotes.Add(note);
         }
     }
@@ -201,6 +204,13 @@ public class InputController : MonoBehaviour
             if (!note.DoesCollide(worldPos)) continue;
             if (!note.CanHandleTouch()) continue;
 
+            // Expand co-located stack members that share this host's collider.
+            if (note.DragStack != null && note.DragStack.IsPrimary(note))
+            {
+                ExpandDragStackIntoBatch(note.DragStack, ref accepted, ref acceptedTime);
+                continue;
+            }
+
             var grade = note.GetTouchGrade();
             if (grade == NoteGrade.None) continue;
             if (grade == NoteGrade.Miss)
@@ -225,6 +235,38 @@ public class InputController : MonoBehaviour
         }
 
         return accepted;
+    }
+
+    private void ExpandDragStackIntoBatch(DragStackHost host, ref Note accepted, ref float acceptedTime)
+    {
+        for (var i = 0; i < host.Members.Count; i++)
+        {
+            var note = host.Members[i];
+            if (!IsTouchableNote(note)) continue;
+            if (!note.CanHandleTouch()) continue;
+
+            var grade = note.GetTouchGrade();
+            if (grade == NoteGrade.None) continue;
+            if (grade == NoteGrade.Miss)
+            {
+                if (accepted == null) note.Clear(NoteGrade.Miss);
+                continue;
+            }
+
+            if (accepted == null)
+            {
+                accepted = note;
+                acceptedTime = EffectiveNoteTime(note);
+                dragBatchScratch.Add(note);
+                continue;
+            }
+
+            if (Math.Abs(EffectiveNoteTime(note) - acceptedTime) > DragStackBatchGapSeconds)
+                continue;
+
+            if (!dragBatchScratch.Contains(note))
+                dragBatchScratch.Add(note);
+        }
     }
 
     /// <summary>

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -131,7 +131,7 @@ public class InputController : MonoBehaviour
 
             if (note.Type == NoteType.DragHead || note.Type == NoteType.DragChild || note.Type == NoteType.CDragChild || note.Type == NoteType.DropDrag)
             {
-                // Stack followers share the primary collider ? only scan primaries here.
+                // Stack followers share the primary collider — only scan primaries here.
                 if (note.IsDragStackFollower) continue;
                 TouchableDragNotes.Add(note);
                 continue;

--- a/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicDragChildNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicDragChildNoteRenderer.cs
@@ -18,6 +18,14 @@ public class ClassicDragChildNoteRenderer : ClassicNoteRenderer
 
     protected override void UpdateComponentStates()
     {
+        if (Note.IsDragStackFollower)
+        {
+            Ring.enabled = false;
+            Fill.enabled = false;
+            SpriteMask.enabled = false;
+            return;
+        }
+
         base.UpdateComponentStates();
         Ring.enabled = false; // Always disable ring
         if (Note.IsCleared)

--- a/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicNoteRenderer.cs
@@ -85,6 +85,12 @@ public class ClassicNoteRenderer : NoteRenderer
 
     protected virtual void UpdateCollider()
     {
+        if (Note.IsDragStackFollower)
+        {
+            Collider.enabled = false;
+            return;
+        }
+
         Collider.enabled = Game.Time >= Note.Model.intro_time && Game.Time <= Note.Model.end_time + Note.MissThreshold;
         
         var radius = Note.Game.Config.NoteHitboxSizes[Note.Type]; // Default hitbox 
@@ -96,6 +102,14 @@ public class ClassicNoteRenderer : NoteRenderer
 
     protected virtual void UpdateComponentStates()
     {
+        if (Note.IsDragStackFollower)
+        {
+            Ring.enabled = false;
+            Fill.enabled = false;
+            if (DisplayNoteId) NoteId.gameObject.SetActive(false);
+            return;
+        }
+
         if (!Note.IsCleared && Game.Time >= Note.Model.intro_time && Game.Time <= Note.Model.end_time + Note.MissThreshold)
         {
             if (Game.State.Mods.Contains(Mod.HideNotes))

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -143,6 +143,7 @@ public class DragHeadNote : Note
                     {
                         Clear(NoteGrade.Miss);
                     }
+                    SyncDragStackFollowersIfPrimary();
                     return;
                 }
 
@@ -167,6 +168,8 @@ public class DragHeadNote : Note
             FromNoteModel = Model;
             ToNoteModel = StartToNoteModel;
         }
+
+        SyncDragStackFollowersIfPrimary();
     }
 
     // SYNC-WARNING: DropDrag judgment is a verbatim copy of DragHeadNote's CanHandleTouch, CalculateGrade,

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -95,10 +95,10 @@ public class DragHeadNote : Note
             while (edgeSteps++ < maxEdgeSteps)
             {
                 var fromPos = (hasFromNote && fromNote != this)
-                    ? fromNote.transform.localPosition
+                    ? fromNote.StackVisualLocalPosition()
                     : FromNoteModel.CalculatePosition(Game.Chart);
                 var toPos = hasToNote
-                    ? toNote.transform.localPosition
+                    ? toNote.StackVisualLocalPosition()
                     : ToNoteModel.CalculatePosition(Game.Chart);
 
                 var span = ToNoteModel.start_time - FromNoteModel.start_time;

--- a/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
@@ -106,7 +106,24 @@ public class DragLineElement : MonoBehaviour
             }
         }
 
-        var fromNotePosition = hasFromNote ? (fromNote is DragHeadNote dragHeadNote ? dragHeadNote.OriginalPosition : fromNote.transform.localPosition) : FromNoteModel.CalculatePosition(Game.Chart);
+        Vector3 fromNotePosition;
+        if (!hasFromNote)
+        {
+            fromNotePosition = FromNoteModel.CalculatePosition(Game.Chart);
+        }
+        else if (fromNote is DragHeadNote dragHeadNote)
+        {
+            // OriginalPosition is only written while Time < start_time; unset (default)
+            // would anchor the line at the world origin and leave a visible stub.
+            fromNotePosition = dragHeadNote.OriginalPosition != default
+                ? dragHeadNote.OriginalPosition
+                : dragHeadNote.transform.localPosition;
+        }
+        else
+        {
+            fromNotePosition = fromNote.transform.localPosition;
+        }
+
         var toNotePosition = hasToNote ? toNote.transform.localPosition : ToNoteModel.CalculatePosition(Game.Chart);
         
         var transform = this.transform;
@@ -125,12 +142,6 @@ public class DragLineElement : MonoBehaviour
         UpdateTransform();
         
         spriteRenderer.enabled = !Game.State.Mods.Contains(Mod.HideNotes);
-
-        if (outroRatio >= 1)
-        {
-            Collect();
-            return;
-        }
 
         if (Game.SpawnedNotes.ContainsKey(FromNoteModel.id))
         {
@@ -176,11 +187,18 @@ public class DragLineElement : MonoBehaviour
             introRatio = time < FromNoteModel.nextdraglinestarttime ? 1.0f : 0.0f;
         }
 
-        var outroSpan = ToNoteModel.start_time - FromNoteModel.start_time;
-        if (outroSpan > 0f)
-            outroRatio = (time - FromNoteModel.start_time) / outroSpan;
+        // Compute outro before Collect so completion happens on the same frame
+        // (avoids a one-frame remnant when _Start is never pulled to 1).
+        var outroDuration = ToNoteModel.start_time - FromNoteModel.start_time;
+        if (outroDuration > 0f)
+        {
+            outroRatio = (time - FromNoteModel.start_time) / outroDuration;
+        }
         else
+        {
+            // Simultaneous or reverse edge: finish once at/after from start (no NaN).
             outroRatio = time < FromNoteModel.start_time ? 0f : 1f;
+        }
 
         if (introRatio > 0 && introRatio < 1)
         {
@@ -195,7 +213,14 @@ public class DragLineElement : MonoBehaviour
             spriteRenderer.material.SetFloat(MaterialEnd, 0.0f);
         }
 
-        if (outroRatio > 0 && outroRatio < 1)
+        if (outroRatio >= 1f)
+        {
+            spriteRenderer.material.SetFloat(MaterialStart, 1f);
+            Collect();
+            return;
+        }
+
+        if (outroRatio > 0f)
         {
             spriteRenderer.material.SetFloat(MaterialStart, outroRatio);
         }

--- a/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
@@ -145,12 +145,7 @@ public class DragLineElement : MonoBehaviour
     static Vector3 VisualPosition(Note note)
     {
         if (note == null) return Vector3.zero;
-        if (note.IsDragStackFollower && note.DragStack?.Primary != null)
-        {
-            return note.DragStack.Primary.transform.localPosition;
-        }
-
-        return note.transform.localPosition;
+        return note.StackVisualLocalPosition();
     }
 
     private void OnGameUpdate(Game _)

--- a/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class DragLineElement : MonoBehaviour
@@ -13,6 +14,11 @@ public class DragLineElement : MonoBehaviour
     public bool IsCollected { get; private set; }
     public ChartModel.Note FromNoteModel { get; private set; }
     public ChartModel.Note ToNoteModel { get; private set; }
+
+    /// <summary>Shared-geometry key assigned by <see cref="ObjectPool"/>; 0 when unset.</summary>
+    public long GeometryKey { get; set; }
+
+    private readonly HashSet<int> geometryFromIds = new HashSet<int>();
 
     private bool hasFromNote;
     private Note fromNote;
@@ -34,6 +40,18 @@ public class DragLineElement : MonoBehaviour
         Game = game;
     }
 
+    public void AddGeometryRef(int fromNoteId)
+    {
+        geometryFromIds.Add(fromNoteId);
+    }
+
+    public List<int> DrainGeometryRefs()
+    {
+        var ids = new List<int>(geometryFromIds);
+        geometryFromIds.Clear();
+        return ids;
+    }
+
     public void Dispose()
     {
         Destroy(gameObject);
@@ -49,6 +67,7 @@ public class DragLineElement : MonoBehaviour
         spriteRenderer.material.SetFloat(MaterialStart, 0.0f);
         UpdateTransform();
         spriteRenderer.sortingOrder = fromNoteModel.id;
+        Game.onGameUpdate.RemoveListener(OnGameUpdate);
         Game.onGameUpdate.AddListener(OnGameUpdate);
     }
 
@@ -118,15 +137,29 @@ public class DragLineElement : MonoBehaviour
             var note = Game.SpawnedNotes[FromNoteModel.id];
             if (!note.IsCleared)
             {
-                if (note.Renderer is ClassicNoteRenderer classicNoteRenderer)
+                // Followers disable Fill; resolve opacity from the stack primary when present.
+                var visual = note;
+                if (note.IsDragStackFollower && note.DragStack?.Primary != null)
+                    visual = note.DragStack.Primary;
+
+                if (visual.Renderer is ClassicNoteRenderer classicNoteRenderer)
                 {
                     var fill = classicNoteRenderer.Fill;
-                    spriteRenderer.color = spriteRenderer.color.WithAlpha(fill.enabled ? fill.color.a : 0);
+                    if (fill != null && fill.enabled)
+                    {
+                        spriteRenderer.color = spriteRenderer.color.WithAlpha(fill.color.a);
+                    }
+                    else
+                    {
+                        var denom = note.Model.start_time - note.Model.intro_time;
+                        var f = denom > 0f ? Mathf.Clamp01(1f - note.TimeUntilStart / denom) : 1f;
+                        spriteRenderer.color = Color.white.WithAlpha(f);
+                    }
                 }
                 else
                 {
-                    var f = 1 - note.TimeUntilStart / (note.Model.start_time - note.Model.intro_time);
-                    f = Mathf.Clamp01(f);
+                    var denom = note.Model.start_time - note.Model.intro_time;
+                    var f = denom > 0f ? Mathf.Clamp01(1f - note.TimeUntilStart / denom) : 1f;
                     spriteRenderer.color = Color.white.WithAlpha(f);
                 }
             }
@@ -184,5 +217,7 @@ public class DragLineElement : MonoBehaviour
         introRatio = default;
         outroRatio = default;
         length = default;
+        GeometryKey = default;
+        geometryFromIds.Clear();
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
@@ -117,14 +117,16 @@ public class DragLineElement : MonoBehaviour
             // would anchor the line at the world origin and leave a visible stub.
             fromNotePosition = dragHeadNote.OriginalPosition != default
                 ? dragHeadNote.OriginalPosition
-                : dragHeadNote.transform.localPosition;
+                : VisualPosition(dragHeadNote);
         }
         else
         {
-            fromNotePosition = fromNote.transform.localPosition;
+            fromNotePosition = VisualPosition(fromNote);
         }
 
-        var toNotePosition = hasToNote ? toNote.transform.localPosition : ToNoteModel.CalculatePosition(Game.Chart);
+        var toNotePosition = hasToNote
+            ? VisualPosition(toNote)
+            : ToNoteModel.CalculatePosition(Game.Chart);
         
         var transform = this.transform;
         transform.localPosition = fromNotePosition;
@@ -133,8 +135,22 @@ public class DragLineElement : MonoBehaviour
             toNotePosition
         );
         spriteRenderer.material.mainTextureScale = new Vector2(1.0f, length / 0.16f);
-        transform.localEulerAngles = hasFromNote ? fromNote.transform.localEulerAngles : FromNoteModel.rotation;
+        // Compatible with Override.Rot*: aim with the from-note euler, not from→to.
+        transform.localEulerAngles = hasFromNote
+            ? fromNote.transform.localEulerAngles
+            : FromNoteModel.rotation;
         transform.localScale = new Vector3(1.0f, length / 0.16f);
+    }
+
+    static Vector3 VisualPosition(Note note)
+    {
+        if (note == null) return Vector3.zero;
+        if (note.IsDragStackFollower && note.DragStack?.Primary != null)
+        {
+            return note.DragStack.Primary.transform.localPosition;
+        }
+
+        return note.transform.localPosition;
     }
 
     private void OnGameUpdate(Game _)
@@ -162,16 +178,12 @@ public class DragLineElement : MonoBehaviour
                     }
                     else
                     {
-                        var denom = note.Model.start_time - note.Model.intro_time;
-                        var f = denom > 0f ? Mathf.Clamp01(1f - note.TimeUntilStart / denom) : 1f;
-                        spriteRenderer.color = Color.white.WithAlpha(f);
+                        spriteRenderer.color = Color.white.WithAlpha(FallbackAlpha(note));
                     }
                 }
                 else
                 {
-                    var denom = note.Model.start_time - note.Model.intro_time;
-                    var f = denom > 0f ? Mathf.Clamp01(1f - note.TimeUntilStart / denom) : 1f;
-                    spriteRenderer.color = Color.white.WithAlpha(f);
+                    spriteRenderer.color = Color.white.WithAlpha(FallbackAlpha(note));
                 }
             }
         }
@@ -224,6 +236,12 @@ public class DragLineElement : MonoBehaviour
         {
             spriteRenderer.material.SetFloat(MaterialStart, outroRatio);
         }
+    }
+
+    static float FallbackAlpha(Note note)
+    {
+        var denom = note.Model.start_time - note.Model.intro_time;
+        return denom > 0f ? Mathf.Clamp01(1f - note.TimeUntilStart / denom) : 1f;
     }
 
     public void Collect()

--- a/engines/unity/Assets/Scripts/Game/Notes/DragStackHost.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragStackHost.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// One visual/collision host for co-located drag notes (size ≥ 2).
+/// Primary note owns Ring/Fill/Collider and Update listeners; followers are judgment-only
+/// and sync transforms from the primary each tick.
+/// </summary>
+public class DragStackHost
+{
+    public int StackId { get; }
+    public Note Primary { get; private set; }
+
+    private readonly List<Note> members = new List<Note>();
+
+    public IReadOnlyList<Note> Members => members;
+
+    public DragStackHost(int stackId)
+    {
+        StackId = stackId;
+    }
+
+    public void Add(Note note)
+    {
+        if (note == null || members.Contains(note)) return;
+
+        var insertAt = members.Count;
+        for (var i = 0; i < members.Count; i++)
+        {
+            if (note.Model.id < members[i].Model.id)
+            {
+                insertAt = i;
+                break;
+            }
+        }
+
+        members.Insert(insertAt, note);
+        note.DragStack = this;
+
+        if (Primary == null)
+        {
+            SetPrimary(note, promote: false);
+        }
+        else
+        {
+            note.BecomeDragStackFollower();
+        }
+    }
+
+    public void OnMemberCollected(Note note)
+    {
+        if (note == null) return;
+        members.Remove(note);
+        if (note.DragStack == this) note.DragStack = null;
+
+        if (Primary == note)
+        {
+            Primary = null;
+            Note next = null;
+            for (var i = 0; i < members.Count; i++)
+            {
+                var candidate = members[i];
+                if (candidate == null || candidate.IsCollected || candidate.IsCleared) continue;
+                next = candidate;
+                break;
+            }
+
+            if (next != null) SetPrimary(next, promote: true);
+        }
+    }
+
+    public bool IsPrimary(Note note) => Primary == note;
+
+    public void TickFollowers(Game game)
+    {
+        if (Primary == null || members.Count == 0) return;
+
+        var primaryPos = Primary.transform.localPosition;
+        var primaryRot = Primary.transform.localEulerAngles;
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            var note = members[i];
+            if (note == null || note == Primary || note.IsCollected) continue;
+
+            note.transform.localPosition = primaryPos;
+            note.transform.localEulerAngles = primaryRot;
+
+            if (!note.IsCleared)
+            {
+                note.TickStackFollowerJudgment();
+            }
+        }
+    }
+
+    private void SetPrimary(Note note, bool promote)
+    {
+        Primary = note;
+        if (promote) note.PromoteToDragStackPrimary();
+        else note.IsDragStackFollower = false;
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Notes/DragStackHost.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragStackHost.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// One visual/collision host for co-located drag notes (size ≥ 2).
+/// One visual/collision host for co-located drag children (size ≥ 2).
 /// Primary note owns Ring/Fill/Collider and Update listeners; followers are judgment-only
 /// and sync transforms from the primary each tick.
 /// </summary>
@@ -40,11 +40,19 @@ public class DragStackHost
         if (Primary == null)
         {
             SetPrimary(note, promote: false);
+            return;
         }
-        else
+
+        // Keep the lowest id as the stable host, independent of spawn order.
+        if (note.Model.id < Primary.Model.id)
         {
-            note.BecomeDragStackFollower();
+            var previous = Primary;
+            SetPrimary(note, promote: false);
+            previous.BecomeDragStackFollower();
+            return;
         }
+
+        note.BecomeDragStackFollower();
     }
 
     public void OnMemberCollected(Note note)
@@ -71,7 +79,7 @@ public class DragStackHost
 
     public bool IsPrimary(Note note) => Primary == note;
 
-    public void TickFollowers(Game game)
+    public void TickFollowers()
     {
         if (Primary == null || members.Count == 0) return;
 

--- a/engines/unity/Assets/Scripts/Game/Notes/DragStackHost.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragStackHost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ed3e4ec4cc2f124bbe60d62e9334b4e

--- a/engines/unity/Assets/Scripts/Game/Notes/DragStackManager.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragStackManager.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Owns live <see cref="DragStackHost"/> instances for the current chart play.
+/// Follower transform sync / judgment is driven by the primary note after its LateUpdate.
+/// </summary>
+public class DragStackManager
+{
+    private readonly Dictionary<int, DragStackHost> hostsByStackId = new Dictionary<int, DragStackHost>();
+    private Game game;
+
+    public void Bind(Game gameInstance)
+    {
+        game = gameInstance;
+        hostsByStackId.Clear();
+    }
+
+    public void Dispose()
+    {
+        hostsByStackId.Clear();
+        game = null;
+    }
+
+    public void Register(Note note)
+    {
+        if (game?.Chart == null || note?.Model == null) return;
+        if (!game.Chart.NoteIdToDragStackId.TryGetValue(note.Model.id, out var stackId)) return;
+
+        if (!hostsByStackId.TryGetValue(stackId, out var host))
+        {
+            host = new DragStackHost(stackId);
+            hostsByStackId[stackId] = host;
+        }
+
+        host.Add(note);
+    }
+
+    public void OnNoteCollected(Note note)
+    {
+        var host = note?.DragStack;
+        if (host == null) return;
+        host.OnMemberCollected(note);
+        if (host.Members.Count == 0)
+        {
+            hostsByStackId.Remove(host.StackId);
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Notes/DragStackManager.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragStackManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 237825afaabfd9e4bb37ceda57597705

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -205,6 +205,13 @@ public abstract class Note : MonoBehaviour
         }
 
         Renderer.OnLateUpdate();
+
+        // Pin followers before LateUpdate so stacked origins match the primary this frame
+        // (lines still lag one Update like unstacked notes; they must not see a pooled pose).
+        if (!(this is DragHeadNote))
+        {
+            SyncDragStackFollowersIfPrimary();
+        }
     }
 
     /// <summary>
@@ -277,9 +284,17 @@ public abstract class Note : MonoBehaviour
             var position = transform.localPosition;
             // Unspawned next notes must use CalculatePosition so Storyboard Override applies
             // (baked .position would aim drag lines/heads at the pre-override chart coord).
-            var nextPosition = hasNextNote
-                ? nextNote.transform.localPosition
-                : NextNoteModel.CalculatePosition(Game.Chart);
+            Vector3 nextPosition;
+            if (hasNextNote)
+            {
+                nextPosition = nextNote.IsDragStackFollower && nextNote.DragStack?.Primary != null
+                    ? nextNote.DragStack.Primary.transform.localPosition
+                    : nextNote.transform.localPosition;
+            }
+            else
+            {
+                nextPosition = NextNoteModel.CalculatePosition(Game.Chart);
+            }
 
             if (position == nextPosition)
                 Model.rotation = Vector3.zero;
@@ -312,7 +327,7 @@ public abstract class Note : MonoBehaviour
     {
         if (DragStack != null && DragStack.IsPrimary(this))
         {
-            DragStack.TickFollowers(Game);
+            DragStack.TickFollowers();
         }
     }
 

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -287,9 +287,7 @@ public abstract class Note : MonoBehaviour
             Vector3 nextPosition;
             if (hasNextNote)
             {
-                nextPosition = nextNote.IsDragStackFollower && nextNote.DragStack?.Primary != null
-                    ? nextNote.DragStack.Primary.transform.localPosition
-                    : nextNote.transform.localPosition;
+                nextPosition = nextNote.StackVisualLocalPosition();
             }
             else
             {
@@ -466,6 +464,16 @@ public abstract class Note : MonoBehaviour
         return Renderer.DoesCollide(pos);
     }
 
+    /// <summary>
+    /// World/local pose used for stacking: followers are pinned to the primary.
+    /// </summary>
+    public Vector3 StackVisualLocalPosition()
+    {
+        if (IsDragStackFollower && DragStack?.Primary != null)
+            return DragStack.Primary.transform.localPosition;
+        return transform.localPosition;
+    }
+
     public void BecomeDragStackFollower()
     {
         if (IsDragStackFollower) return;
@@ -483,6 +491,8 @@ public abstract class Note : MonoBehaviour
         Game.onGameLateUpdate.RemoveListener(OnGameLateUpdate);
         Game.onGameUpdate.AddListener(OnGameUpdate);
         Game.onGameLateUpdate.AddListener(OnGameLateUpdate);
+        // Restore Ring/Fill/Mask this frame; waiting for the next Update leaves a blank host.
+        Renderer?.OnLateUpdate();
     }
 
     private void SetDragStackVisualsEnabled(bool enabled)
@@ -497,7 +507,6 @@ public abstract class Note : MonoBehaviour
             var masks = GetComponentsInChildren<SpriteMask>(true);
             for (var i = 0; i < masks.Length; i++) masks[i].enabled = false;
         }
-        // When enabling, ClassicNoteRenderer.OnLateUpdate restores sprite visibility.
     }
 
     public virtual bool IsAutoEnabled()

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -34,6 +34,12 @@ public abstract class Note : MonoBehaviour
     private bool dragStackBudgetPending;
     private int dragStackBudgetId;
 
+    /// <summary>Co-located drag stack host; null when not in a multi-note stack.</summary>
+    public DragStackHost DragStack { get; set; }
+
+    /// <summary>True when this note shares visuals/collider with <see cref="DragStack"/>.Primary.</summary>
+    public bool IsDragStackFollower { get; set; }
+
     // For ranked mode: weighted difference between the current timing and the perfect timing
     public float GreatGradeWeight { get; protected set; }
 
@@ -59,6 +65,8 @@ public abstract class Note : MonoBehaviour
         armedGrade = NoteGrade.None;
         dragStackBudgetPending = false;
         dragStackBudgetId = 0;
+        IsDragStackFollower = false;
+        DragStack = null;
     
         Chart = Game.Chart.Model;
         Model = Game.Chart.Model.note_map[noteId];
@@ -71,9 +79,14 @@ public abstract class Note : MonoBehaviour
         Type = (NoteType) Model.type;
 
         Renderer.OnNoteLoaded();
+        var collider = Renderer.GetCollider();
+        if (collider != null) collider.enabled = true;
+
         MissThreshold = Type.GetDefaultMissThreshold();
         JudgmentOffset = Context.Player.Settings.JudgmentOffset;
 
+        Game.onGameUpdate.RemoveListener(OnGameUpdate);
+        Game.onGameLateUpdate.RemoveListener(OnGameLateUpdate);
         Game.onGameUpdate.AddListener(OnGameUpdate);
         Game.onGameLateUpdate.AddListener(OnGameLateUpdate);
     }
@@ -90,6 +103,7 @@ public abstract class Note : MonoBehaviour
         IsCollected = true;
 
         Renderer.OnCollect();
+        Game.ObjectPool.DragStacks.OnNoteCollected(this);
         Game.ObjectPool.CollectNote(this);
         Game.onGameUpdate.RemoveListener(OnGameUpdate);
         Game.onGameLateUpdate.RemoveListener(OnGameLateUpdate);
@@ -107,6 +121,8 @@ public abstract class Note : MonoBehaviour
         dragStackBudgetId = 0;
         GreatGradeWeight = default;
         JudgmentOffset = default;
+        DragStack = null;
+        IsDragStackFollower = default;
     }
 
     public virtual void Clear(NoteGrade grade)
@@ -178,49 +194,67 @@ public abstract class Note : MonoBehaviour
 
     protected virtual void OnGameUpdate(Game _)
     {
+        if (IsDragStackFollower) return;
+
         if (!IsCleared)
         {
             // Update position
             gameObject.transform.localPosition = Model.CalculatePosition(Game.Chart);
 
-            if (IsArmed)
-            {
-                if (Game.Time >= Model.start_time + JudgmentOffset)
-                {
-                    Clear(armedGrade);
-                }
-            }
-            else
-            {
-                // Autoplay
-                if (IsAutoEnabled())
-                {
-                    if (TimeUntilStart < 0)
-                    {
-                        if (this is HoldNote)
-                        {
-                            ((HoldNote) this).UpdateFinger(0, true);
-                        }
-                        else
-                        {
-                            Clear(NoteGrade.Perfect);
-                        }
-                    }
-                }
-
-                // Check removable
-                if (ShouldMiss())
-                {
-                    Clear(NoteGrade.Miss);
-                }
-            }
+            TickJudgmentState();
         }
 
         Renderer.OnLateUpdate();
     }
 
+    /// <summary>
+    /// Armed / Auto / Miss settlement shared by primary Update and stack followers.
+    /// </summary>
+    public void TickStackFollowerJudgment()
+    {
+        if (IsCleared || IsCollected) return;
+        TickJudgmentState();
+    }
+
+    private void TickJudgmentState()
+    {
+        if (IsArmed)
+        {
+            if (Game.Time >= Model.start_time + JudgmentOffset)
+            {
+                Clear(armedGrade);
+            }
+        }
+        else
+        {
+            // Autoplay
+            if (IsAutoEnabled())
+            {
+                if (TimeUntilStart < 0)
+                {
+                    if (this is HoldNote)
+                    {
+                        ((HoldNote) this).UpdateFinger(0, true);
+                    }
+                    else
+                    {
+                        Clear(NoteGrade.Perfect);
+                    }
+                }
+            }
+
+            // Check removable
+            if (ShouldMiss())
+            {
+                Clear(NoteGrade.Miss);
+            }
+        }
+    }
+
     protected virtual void OnGameLateUpdate(Game _)
     {
+        if (IsDragStackFollower) return;
+
         if (NextNoteModel != null)
         {
             if (Game.SpawnedNotes.ContainsKey(NextNoteModel.id))
@@ -266,6 +300,20 @@ public abstract class Note : MonoBehaviour
         if (Model.Override.RotZ != null) rotation.z = Model.Override.RotZ.Value;
 
         gameObject.transform.localEulerAngles = Model.rotation = rotation;
+
+        // DragHead syncs after it finishes moving in its LateUpdate override.
+        if (!(this is DragHeadNote))
+        {
+            SyncDragStackFollowersIfPrimary();
+        }
+    }
+
+    protected void SyncDragStackFollowersIfPrimary()
+    {
+        if (DragStack != null && DragStack.IsPrimary(this))
+        {
+            DragStack.TickFollowers(Game);
+        }
     }
 
     public virtual bool ShouldMiss()
@@ -395,7 +443,46 @@ public abstract class Note : MonoBehaviour
 
     public bool DoesCollide(Vector2 pos)
     {
+        if (IsDragStackFollower && DragStack?.Primary != null)
+        {
+            return DragStack.Primary.DoesCollide(pos);
+        }
+
         return Renderer.DoesCollide(pos);
+    }
+
+    public void BecomeDragStackFollower()
+    {
+        if (IsDragStackFollower) return;
+        IsDragStackFollower = true;
+        Game.onGameUpdate.RemoveListener(OnGameUpdate);
+        Game.onGameLateUpdate.RemoveListener(OnGameLateUpdate);
+        SetDragStackVisualsEnabled(false);
+    }
+
+    public void PromoteToDragStackPrimary()
+    {
+        IsDragStackFollower = false;
+        SetDragStackVisualsEnabled(true);
+        Game.onGameUpdate.RemoveListener(OnGameUpdate);
+        Game.onGameLateUpdate.RemoveListener(OnGameLateUpdate);
+        Game.onGameUpdate.AddListener(OnGameUpdate);
+        Game.onGameLateUpdate.AddListener(OnGameLateUpdate);
+    }
+
+    private void SetDragStackVisualsEnabled(bool enabled)
+    {
+        var colliders = GetComponentsInChildren<Collider2D>(true);
+        for (var i = 0; i < colliders.Length; i++) colliders[i].enabled = enabled;
+
+        if (!enabled)
+        {
+            var sprites = GetComponentsInChildren<SpriteRenderer>(true);
+            for (var i = 0; i < sprites.Length; i++) sprites[i].enabled = false;
+            var masks = GetComponentsInChildren<SpriteMask>(true);
+            for (var i = 0; i < masks.Length; i++) masks[i].enabled = false;
+        }
+        // When enabling, ClassicNoteRenderer.OnLateUpdate restores sprite visibility.
     }
 
     public virtual bool IsAutoEnabled()

--- a/engines/unity/Assets/Scripts/Game/ObjectPool.cs
+++ b/engines/unity/Assets/Scripts/Game/ObjectPool.cs
@@ -43,10 +43,9 @@ public class ObjectPool
     /// </summary>
     public int Generation { get; private set; }
 
-    /// <summary>Geometry key → live shared drag line.</summary>
-    private readonly Dictionary<long, DragLineElement> dragLinesByGeometry = new Dictionary<long, DragLineElement>();
-    private readonly Dictionary<long, int> dragLineGeometryRefCount = new Dictionary<long, int>();
-    private readonly Dictionary<int, long> dragLineFromIdToGeometry = new Dictionary<int, long>();
+    /// <summary>Share key → live shared drag line.</summary>
+    private readonly Dictionary<long, DragLineElement> dragLinesByShareKey = new Dictionary<long, DragLineElement>();
+    private readonly Dictionary<int, long> dragLineFromIdToShareKey = new Dictionary<int, long>();
 
     public Game Game { get; }
 
@@ -72,26 +71,15 @@ public class ObjectPool
     {
         DragStacks.Bind(Game);
 
-        initialDragLineObjectCount = Mathf.Clamp(
-            initialNoteObjectCount[NoteType.DragHead]
-            + initialNoteObjectCount[NoteType.DragChild]
-            + initialNoteObjectCount[NoteType.CDragHead]
-            + initialNoteObjectCount[NoteType.CDragChild],
-            1,
-            MaxPooledDragLines);
-
-        // Prefer host count when stacks exist — far smaller than raw drag note peaks.
         var chart = Game.Chart;
-        if (chart.MaxSamePageDragStackHostCount > 0)
-        {
-            var hostBased = Mathf.Max(
-                chart.MaxSamePageDragStackHostCount * 2,
-                chart.MaxSamePageNoteCountByType.TryGetValue(NoteType.Click, out var clickCount) ? clickCount : 24);
-            initialDragLineObjectCount = Mathf.Clamp(
-                Mathf.Max(initialDragLineObjectCount / 4, hostBased),
-                1,
-                MaxPooledDragLines);
-        }
+        // Prefer the post-storyboard line bound (stack hosts + unshared edges) when present.
+        var dragLineBound = chart.MaxSamePageDragLineCount > 0
+            ? chart.MaxSamePageDragLineCount * 3
+            : initialNoteObjectCount[NoteType.DragHead]
+              + initialNoteObjectCount[NoteType.DragChild]
+              + initialNoteObjectCount[NoteType.CDragHead]
+              + initialNoteObjectCount[NoteType.CDragChild];
+        initialDragLineObjectCount = Mathf.Clamp(dragLineBound, 1, MaxPooledDragLines);
 
         var timer = new BenchmarkTimer("Game ObjectPool");
         foreach (var type in initialNoteObjectCount.Keys)
@@ -158,9 +146,8 @@ public class ObjectPool
         foreach (var line in SpawnedDragLines.Values) uniqueLines.Add(line);
         foreach (var line in uniqueLines) line.Dispose();
         SpawnedDragLines.Clear();
-        dragLinesByGeometry.Clear();
-        dragLineGeometryRefCount.Clear();
-        dragLineFromIdToGeometry.Clear();
+        dragLinesByShareKey.Clear();
+        dragLineFromIdToShareKey.Clear();
         dragLinePoolItem.Dispose();
         effectPoolItems.Values.ForEach(it => it.Dispose());
     }
@@ -186,11 +173,10 @@ public class ObjectPool
     {
         if (SpawnedDragLines.ContainsKey(from.id)) return SpawnedDragLines[from.id];
 
-        var geometryKey = MakeDragLineGeometryKey(from, to);
-        if (dragLinesByGeometry.TryGetValue(geometryKey, out var shared))
+        var shareKey = DragStackPlanner.MakeDragLineShareKey(from, to, Game.Chart.NoteIdToDragStackId);
+        if (shareKey != 0 && dragLinesByShareKey.TryGetValue(shareKey, out var shared))
         {
-            dragLineGeometryRefCount[geometryKey] = dragLineGeometryRefCount[geometryKey] + 1;
-            dragLineFromIdToGeometry[from.id] = geometryKey;
+            dragLineFromIdToShareKey[from.id] = shareKey;
             shared.AddGeometryRef(from.id);
             SpawnedDragLines[from.id] = shared;
             return shared;
@@ -198,11 +184,14 @@ public class ObjectPool
 
         var line = Spawn(dragLinePoolItem, new PoolItemInstantiateProvider(),
             new DragLineSpawnProvider {From = from, To = to});
-        line.GeometryKey = geometryKey;
+        line.GeometryKey = shareKey;
         line.AddGeometryRef(from.id);
-        dragLinesByGeometry[geometryKey] = line;
-        dragLineGeometryRefCount[geometryKey] = 1;
-        dragLineFromIdToGeometry[from.id] = geometryKey;
+        if (shareKey != 0)
+        {
+            dragLinesByShareKey[shareKey] = line;
+        }
+
+        dragLineFromIdToShareKey[from.id] = shareKey;
         SpawnedDragLines[from.id] = line;
         return line;
     }
@@ -214,39 +203,22 @@ public class ObjectPool
         var key = element.GeometryKey;
         if (key != 0)
         {
-            dragLinesByGeometry.Remove(key);
-            dragLineGeometryRefCount.Remove(key);
+            dragLinesByShareKey.Remove(key);
         }
 
         foreach (var fromId in element.DrainGeometryRefs())
         {
             SpawnedDragLines.Remove(fromId);
-            dragLineFromIdToGeometry.Remove(fromId);
+            dragLineFromIdToShareKey.Remove(fromId);
         }
 
         if (element.FromNoteModel != null)
         {
             SpawnedDragLines.Remove(element.FromNoteModel.id);
-            dragLineFromIdToGeometry.Remove(element.FromNoteModel.id);
+            dragLineFromIdToShareKey.Remove(element.FromNoteModel.id);
         }
 
         Collect(dragLinePoolItem, element);
-    }
-
-    private static long MakeDragLineGeometryKey(ChartModel.Note from, ChartModel.Note to)
-    {
-        // Include note type so Drag vs CDrag edges with matching quantized (t,x) do not share.
-        unchecked
-        {
-            long hash = 17;
-            hash = hash * 31 + from.type;
-            hash = hash * 31 + to.type;
-            hash = hash * 31 + (long) Mathf.Round(from.start_time * 1000f);
-            hash = hash * 31 + (long) Mathf.Round(to.start_time * 1000f);
-            hash = hash * 31 + (long) Mathf.Round((float) from.x * 10000f);
-            hash = hash * 31 + (long) Mathf.Round((float) to.x * 10000f);
-            return hash;
-        }
     }
 
     public ParticleSystem SpawnEffect(EffectController.Effect effect, Vector3 position, Transform parent = default)

--- a/engines/unity/Assets/Scripts/Game/ObjectPool.cs
+++ b/engines/unity/Assets/Scripts/Game/ObjectPool.cs
@@ -25,6 +25,15 @@ public class ObjectPool
     public readonly SortedDictionary<int, Note> SpawnedNotes = new SortedDictionary<int, Note>(); // Currently on-screen
     public readonly SortedDictionary<int, DragLineElement> SpawnedDragLines = new SortedDictionary<int, DragLineElement>();
 
+    public readonly DragStackManager DragStacks = new DragStackManager();
+
+    /// <summary>Hard caps so MaxSamePage on stress charts cannot preallocate thousands of FX.</summary>
+    public const int MaxPooledClearEffects = 64;
+    public const int MaxPooledMissEffects = 64;
+    public const int MaxPooledHoldEffects = 128;
+    public const int MaxPooledNotesPerType = 256;
+    public const int MaxPooledDragLines = 256;
+
     private readonly Dictionary<NoteType, NotePoolItem> notePoolItems = new Dictionary<NoteType, NotePoolItem>();
     private readonly DragLinePoolItem dragLinePoolItem = new DragLinePoolItem();
     private readonly Dictionary<EffectController.Effect, PrefabPoolItem> effectPoolItems = new Dictionary<EffectController.Effect, PrefabPoolItem>();
@@ -33,6 +42,11 @@ public class ObjectPool
     /// Bumped on <see cref="Dispose"/> so delayed FX collect callbacks can no-op.
     /// </summary>
     public int Generation { get; private set; }
+
+    /// <summary>Geometry key → live shared drag line.</summary>
+    private readonly Dictionary<long, DragLineElement> dragLinesByGeometry = new Dictionary<long, DragLineElement>();
+    private readonly Dictionary<long, int> dragLineGeometryRefCount = new Dictionary<long, int>();
+    private readonly Dictionary<int, long> dragLineFromIdToGeometry = new Dictionary<int, long>();
 
     public Game Game { get; }
 
@@ -51,15 +65,34 @@ public class ObjectPool
 
     public void UpdateNoteObjectCount(NoteType type, int count)
     {
-        initialNoteObjectCount[type] = count;
+        initialNoteObjectCount[type] = Mathf.Clamp(count, 1, MaxPooledNotesPerType);
     }
 
     public void Initialize()
     {
-        initialDragLineObjectCount = initialNoteObjectCount[NoteType.DragHead]
-                                     + initialNoteObjectCount[NoteType.DragChild]
-                                     + initialNoteObjectCount[NoteType.CDragHead]
-                                     + initialNoteObjectCount[NoteType.CDragChild];
+        DragStacks.Bind(Game);
+
+        initialDragLineObjectCount = Mathf.Clamp(
+            initialNoteObjectCount[NoteType.DragHead]
+            + initialNoteObjectCount[NoteType.DragChild]
+            + initialNoteObjectCount[NoteType.CDragHead]
+            + initialNoteObjectCount[NoteType.CDragChild],
+            1,
+            MaxPooledDragLines);
+
+        // Prefer host count when stacks exist — far smaller than raw drag note peaks.
+        var chart = Game.Chart;
+        if (chart.MaxSamePageDragStackHostCount > 0)
+        {
+            var hostBased = Mathf.Max(
+                chart.MaxSamePageDragStackHostCount * 2,
+                chart.MaxSamePageNoteCountByType.TryGetValue(NoteType.Click, out var clickCount) ? clickCount : 24);
+            initialDragLineObjectCount = Mathf.Clamp(
+                Mathf.Max(initialDragLineObjectCount / 4, hostBased),
+                1,
+                MaxPooledDragLines);
+        }
+
         var timer = new BenchmarkTimer("Game ObjectPool");
         foreach (var type in initialNoteObjectCount.Keys)
         {
@@ -74,24 +107,23 @@ public class ObjectPool
             Collect(dragLinePoolItem, Instantiate(dragLinePoolItem, new PoolItemInstantiateProvider()));
         }
         timer.Time("DragLines");
-        var chart = Game.Chart;
         var map = new Dictionary<EffectController.Effect, int>
         {
             {
                 EffectController.Effect.Clear,
-                chart.MaxSamePageNonDragTypeNoteCount * 2
+                Mathf.Clamp(chart.MaxSamePageNonDragTypeNoteCount * 2, 1, MaxPooledClearEffects)
             },
             {
                 EffectController.Effect.ClearDrag,
-                chart.MaxSamePageDragTypeNoteCount * 2
+                Mathf.Clamp(chart.MaxSamePageDragTypeNoteCount * 2, 1, MaxPooledClearEffects)
             },
             {
                 EffectController.Effect.Miss,
-                chart.MaxSamePageNoteCount * 2
+                Mathf.Clamp(chart.MaxSamePageNoteCount * 2, 1, MaxPooledMissEffects)
             },
             {
                 EffectController.Effect.Hold,
-                chart.MaxSamePageHoldTypeNoteCount * 16 * 2
+                Mathf.Clamp(chart.MaxSamePageHoldTypeNoteCount * 16 * 2, 1, MaxPooledHoldEffects)
             }
         };
         foreach (var pair in map)
@@ -116,17 +148,20 @@ public class ObjectPool
     public void Dispose()
     {
         Generation++;
-
+        DragStacks.Dispose();
         SpawnedNotes.Values.ForEach(it => it.Dispose());
         SpawnedNotes.Clear();
         notePoolItems.Values.ForEach(it => it.Dispose());
 
-        // Active drag lines are not in the pool queue.
-        foreach (var line in SpawnedDragLines.Values.ToList())
-            line.Dispose();
+        // Shared geometry may map many from-ids to one GO.
+        var uniqueLines = new HashSet<DragLineElement>();
+        foreach (var line in SpawnedDragLines.Values) uniqueLines.Add(line);
+        foreach (var line in uniqueLines) line.Dispose();
         SpawnedDragLines.Clear();
+        dragLinesByGeometry.Clear();
+        dragLineGeometryRefCount.Clear();
+        dragLineFromIdToGeometry.Clear();
         dragLinePoolItem.Dispose();
-
         effectPoolItems.Values.ForEach(it => it.Dispose());
     }
 
@@ -135,6 +170,7 @@ public class ObjectPool
         if (SpawnedNotes.ContainsKey(model.id)) return SpawnedNotes[model.id];
         var note = Spawn(notePoolItems[(NoteType) model.type], new NoteInstantiateProvider{Type = (NoteType) model.type}, new NoteSpawnProvider{Model = model});
         SpawnedNotes[model.id] = note;
+        DragStacks.Register(note);
         return note;
     }
 
@@ -149,15 +185,66 @@ public class ObjectPool
     public DragLineElement SpawnDragLine(ChartModel.Note from, ChartModel.Note to)
     {
         if (SpawnedDragLines.ContainsKey(from.id)) return SpawnedDragLines[from.id];
-        return SpawnedDragLines[from.id] = Spawn(dragLinePoolItem, new PoolItemInstantiateProvider(),
+
+        var geometryKey = MakeDragLineGeometryKey(from, to);
+        if (dragLinesByGeometry.TryGetValue(geometryKey, out var shared))
+        {
+            dragLineGeometryRefCount[geometryKey] = dragLineGeometryRefCount[geometryKey] + 1;
+            dragLineFromIdToGeometry[from.id] = geometryKey;
+            shared.AddGeometryRef(from.id);
+            SpawnedDragLines[from.id] = shared;
+            return shared;
+        }
+
+        var line = Spawn(dragLinePoolItem, new PoolItemInstantiateProvider(),
             new DragLineSpawnProvider {From = from, To = to});
+        line.GeometryKey = geometryKey;
+        line.AddGeometryRef(from.id);
+        dragLinesByGeometry[geometryKey] = line;
+        dragLineGeometryRefCount[geometryKey] = 1;
+        dragLineFromIdToGeometry[from.id] = geometryKey;
+        SpawnedDragLines[from.id] = line;
+        return line;
     }
 
     public void CollectDragLine(DragLineElement element)
     {
-        if (!SpawnedDragLines.ContainsKey(element.FromNoteModel.id)) return;
+        if (element == null) return;
+
+        var key = element.GeometryKey;
+        if (key != 0)
+        {
+            dragLinesByGeometry.Remove(key);
+            dragLineGeometryRefCount.Remove(key);
+        }
+
+        foreach (var fromId in element.DrainGeometryRefs())
+        {
+            SpawnedDragLines.Remove(fromId);
+            dragLineFromIdToGeometry.Remove(fromId);
+        }
+
+        if (element.FromNoteModel != null)
+        {
+            SpawnedDragLines.Remove(element.FromNoteModel.id);
+            dragLineFromIdToGeometry.Remove(element.FromNoteModel.id);
+        }
+
         Collect(dragLinePoolItem, element);
-        SpawnedDragLines.Remove(element.FromNoteModel.id);
+    }
+
+    private static long MakeDragLineGeometryKey(ChartModel.Note from, ChartModel.Note to)
+    {
+        // Full quantized coords — do not fold x into 10 bits (that collided unrelated edges).
+        unchecked
+        {
+            long hash = 17;
+            hash = hash * 31 + (long) Mathf.Round(from.start_time * 1000f);
+            hash = hash * 31 + (long) Mathf.Round(to.start_time * 1000f);
+            hash = hash * 31 + (long) Mathf.Round((float) from.x * 10000f);
+            hash = hash * 31 + (long) Mathf.Round((float) to.x * 10000f);
+            return hash;
+        }
     }
 
     public ParticleSystem SpawnEffect(EffectController.Effect effect, Vector3 position, Transform parent = default)
@@ -290,6 +377,8 @@ public class ObjectPool
         public override void OnCollect(Game game, Note note)
         {
             if (note == null || note.gameObject == null) return;
+            note.IsDragStackFollower = false;
+            note.DragStack = null;
             note.gameObject.SetActive(false);
         }
 
@@ -325,6 +414,7 @@ public class ObjectPool
         public override void OnCollect(Game game, DragLineElement dragLine)
         {
             if (dragLine == null || dragLine.gameObject == null) return;
+            dragLine.GeometryKey = 0;
             dragLine.gameObject.SetActive(false);
         }
 

--- a/engines/unity/Assets/Scripts/Game/ObjectPool.cs
+++ b/engines/unity/Assets/Scripts/Game/ObjectPool.cs
@@ -103,7 +103,7 @@ public class ObjectPool
             },
             {
                 EffectController.Effect.ClearDrag,
-                Mathf.Clamp(chart.MaxSamePageDragTypeNoteCount * 2, 1, MaxPooledClearEffects)
+                ClearDragPoolCount(chart)
             },
             {
                 EffectController.Effect.Miss,
@@ -131,6 +131,64 @@ public class ObjectPool
         }
         timer.Time("Effects");
         timer.Time();
+    }
+
+    /// <summary>
+    /// ClearDrag prewarm after stacking. Unstacked drag notes still need a slot each;
+    /// each stack contributes at most <see cref="EffectController.MaxClearFxPerDragBatch"/>.
+    /// <see cref="Chart.MaxSamePageDragStackHostCount"/> is the floor so a page of
+    /// hosts cannot prewarm below one slot per host.
+    /// </summary>
+    static int ClearDragPoolCount(Chart chart)
+    {
+        var fallback = Mathf.Clamp(chart.MaxSamePageDragTypeNoteCount * 2, 1, MaxPooledClearEffects);
+        var hostPeak = chart.MaxSamePageDragStackHostCount;
+        if (hostPeak <= 0) return fallback;
+
+        var pageCount = chart.Model?.page_list != null ? chart.Model.page_list.Count : 0;
+        if (pageCount <= 0) return fallback;
+
+        var perPage = new int[pageCount];
+        var stacked = chart.NoteIdToDragStackId;
+        var noteList = chart.Model.note_list;
+        if (noteList != null)
+        {
+            for (var i = 0; i < noteList.Count; i++)
+            {
+                var note = noteList[i];
+                if (note == null) continue;
+                var type = (NoteType) note.type;
+                if (type != NoteType.DragHead && type != NoteType.DragChild && type != NoteType.CDragChild)
+                    continue;
+                if (stacked != null && stacked.ContainsKey(note.id)) continue;
+                var page = note.page_index;
+                if (page < 0 || page >= pageCount) continue;
+                perPage[page]++;
+            }
+        }
+
+        if (chart.DragStackMembers != null)
+        {
+            var noteMap = chart.Model.note_map;
+            foreach (var pair in chart.DragStackMembers)
+            {
+                var members = pair.Value;
+                if (members == null || members.Count == 0) continue;
+                ChartModel.Note first = null;
+                if (noteMap != null) noteMap.TryGetValue(members[0], out first);
+                var page = first != null ? first.page_index : 0;
+                if (page < 0 || page >= pageCount) continue;
+                perPage[page] += Mathf.Min(EffectController.MaxClearFxPerDragBatch, members.Count);
+            }
+        }
+
+        var max = hostPeak;
+        for (var i = 0; i < perPage.Length; i++)
+        {
+            if (perPage[i] > max) max = perPage[i];
+        }
+
+        return Mathf.Clamp(max * 2, 1, MaxPooledClearEffects);
     }
 
     public void Dispose()

--- a/engines/unity/Assets/Scripts/Game/ObjectPool.cs
+++ b/engines/unity/Assets/Scripts/Game/ObjectPool.cs
@@ -235,10 +235,12 @@ public class ObjectPool
 
     private static long MakeDragLineGeometryKey(ChartModel.Note from, ChartModel.Note to)
     {
-        // Full quantized coords — do not fold x into 10 bits (that collided unrelated edges).
+        // Include note type so Drag vs CDrag edges with matching quantized (t,x) do not share.
         unchecked
         {
             long hash = 17;
+            hash = hash * 31 + from.type;
+            hash = hash * 31 + to.type;
             hash = hash * 31 + (long) Mathf.Round(from.start_time * 1000f);
             hash = hash * 31 + (long) Mathf.Round(to.start_time * 1000f);
             hash = hash * 31 + (long) Mathf.Round((float) from.x * 10000f);


### PR DESCRIPTION
## Summary
- After storyboard parse/initialize, group only `DragChild` / `CDragChild` notes that share a full visual key (including `intro_time`), the same storyboard note-controller signature, and equivalent next-note destinations. Heads keep their own chain motion and are never stacked.
- One `DragStackHost` per stack: lowest id is primary (Ring/Fill/Mask/collider + Update); followers are judgment-only and copy the primary transform. Lines share by stack identity of both endpoints, still aiming with the from-note euler (`Override.Rot*`).
- Compose with current main: `#203` scoped drag-stack FX/SFX (not a global 3/1 cap), `#206` `CalculatePosition` for unspawned next notes, promote restores sprites the same frame, and a failed/partial storyboard does not feed `NoteControllers` into the planner.
- `MaxSamePageDragStackHostCount` now floors ClearDrag pool prewarm after stacking; drag-line pool still uses `MaxSamePageDragLineCount`.

## Review notes
- Dense copy-paste 密锁: each co-located child column stacks; connecting lines share; heads stay independent.
- Trigger-spawned note controllers get a unique per-note signature and never merge.
- Prerequisite FX/batch/lifecycle work is already on main (`#199`, `#203`, `#204`, `#206`); this PR no longer carries those commits.

## Test plan
- [ ] Dense stacked drag chart (ptb10_yee extreme or similar): page before climax stays playable; drag lines remain visible
- [ ] After judgment: no short white drag-line remnant stubs
- [ ] Stack settle: at most ~3 clear FX / 1 hit sound **per co-located stack**, Click/Flick/Hold/Auto uncapped
- [ ] Normal spaced drag chain: no skipped notes / no shared-line teardown of unrelated edges
- [ ] Storyboard that moves one child independently: that chain does not share a host or line
- [ ] Failed storyboard load: stacking still runs as uncontrolled (no signatures), session does not treat a disposed storyboard as active
- [ ] Primary promote after the first stacked child collects: Ring/Fill/Mask restore the same frame
- [ ] Drag + Click/Flick DragCoHit gating unchanged vs main
- [ ] Deferred early drag contact still arms to perfect time
- [ ] Pool init log: ClearDrag on a dense stacked page follows host count, not raw child count
- [ ] Auto through dense stacks: no lingering lines / no origin-anchored fly lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for grouping compatible drag notes into stacks, with automatic follower promotion as notes are collected.
  - Drag interactions now handle stacked and nearby simultaneous notes as coordinated batches.
  - Drag lines can share geometry, improving handling of overlapping drag paths.

- **Bug Fixes**
  - Improved drag-head movement across zero-length segments and complex paths.
  - Prevented stacked follower notes from appearing or responding as separate interactive notes.
  - Improved touch, flick, hold, judgment, and pause behavior for grouped drags.

- **Performance**
  - Added safeguards and limits for pooled notes, effects, sounds, and drag-line resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->