### PR TITLE
fix(gameplay): keep boundary lines at static play-area edges

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -440,17 +440,9 @@ public class Chart
         return ConvertChartYToScreenY(percentage);
     }
 
-    public float GetPageBoundaryScreenY(int pageId, bool bottom)
-    {
-        pageId = Mathf.Clamp(pageId, 0, Model.page_list.Count - 1);
-        var page = Model.page_list[pageId];
-        PositionFunction.GetVisibleBand(page, out var low, out var high);
-        return PageDisplayYToScreenY(bottom ? low : high);
-    }
-
     /// <summary>
-    /// Full play-area top/bottom (always ±baseSize). Page-aware bands use
-    /// <see cref="GetPageBoundaryScreenY"/> instead.
+    /// Full play-area top/bottom (always ±baseSize), independent of the per-page
+    /// PositionFunction band.
     /// </summary>
     public float GetBoundaryPosition(bool bottom)
     {

--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
@@ -26,44 +26,6 @@ public static class PositionFunction
     }
 
     /// <summary>
-    /// Visible play-area band in display Y (always <paramref name="low"/> ≤ <paramref name="high"/>).
-    /// </summary>
-    public static void GetVisibleBand(ChartModel.Page page, out float low, out float high)
-    {
-        var a = page.position_arg_a;
-        var b = page.position_arg_b;
-        if (Mathf.Approximately(a, 0f))
-        {
-            var y = Mathf.Clamp(b, -1f, 1f);
-            low = y;
-            high = y;
-            return;
-        }
-
-        var y0 = b - a;
-        var y1 = b + a;
-        var sortedLo = Mathf.Min(y0, y1);
-        var sortedHi = Mathf.Max(y0, y1);
-
-        if (sortedHi < -1f)
-        {
-            low = -1f;
-            high = -1f;
-            return;
-        }
-
-        if (sortedLo > 1f)
-        {
-            low = 1f;
-            high = 1f;
-            return;
-        }
-
-        low = Mathf.Max(sortedLo, -1f);
-        high = Mathf.Min(sortedHi, 1f);
-    }
-
-    /// <summary>
     /// Normalized play-area Y in [-1, 1] (bottom = -1).
     /// </summary>
     public static float EvaluateDisplayY(ChartModel.Page page, float chronologicalT)

--- a/engines/unity/Assets/Scripts/Game/Notes/GameRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/GameRenderer.cs
@@ -135,12 +135,9 @@ public class GameRenderer
             boundaryBottomAnimator.speed = boundaryTopAnimator.speed;
         }
 
-        if (chart.Model.page_list.Count > 0)
-        {
-            var pageId = Mathf.Min(chart.CurrentPageId, chart.Model.page_list.Count - 1);
-            boundaryTop.transform.position = new Vector3(0, chart.GetPageBoundaryScreenY(pageId, false), 0);
-            boundaryBottom.transform.position = new Vector3(0, chart.GetPageBoundaryScreenY(pageId, true), 0);
-        }
+        // By design boundaries are static; they intentionally do not follow the per-page PositionFunction band.
+        boundaryTop.transform.position = new Vector3(0, chart.GetBoundaryPosition(false), 0);
+        boundaryBottom.transform.position = new Vector3(0, chart.GetBoundaryPosition(true), 0);
         if (Game.State.IsStarted && Game.State.IsPlaying && !Game.State.IsCompleted)
         {
             ApplyBoundaryOpacity();


### PR DESCRIPTION
> Mirror of Cytoid-private#62 — same diff, same commit split.

## Summary

Boundary lines are designed to stay fixed at the full play-area top/bottom edges. However, the C2 PositionFunction port wired GameRenderer's boundary lines to the per-page visible band (`GetPageBoundaryScreenY`), which causes:

- In charts with non-default PositionFunction args (a≠1 / b≠0), boundary lines move on page turns
- With a≈0, the top and bottom boundary lines collapse onto a single line
- When the band lies entirely off screen, both lines pin to the screen edge

This PR restores static boundary positioning via `GetBoundaryPosition` (±`verticalRatio * baseSize + verticalOffset`). With default args the values are bit-identical to the original implementation, so this is fully backward compatible.

## Changes

- `GameRenderer.OnUpdate`: boundary lines return to static `GetBoundaryPosition`, no longer tracking CurrentPageId's per-page band
- `Chart`: remove `GetPageBoundaryScreenY`, whose only caller is now gone (`GetBoundaryPosition` stays — still used by `GamePlayRecord.Complete()`, now consistent with rendering)
- `PositionFunction`: remove the now-unused `GetVisibleBand` (the evaluator keeps only `BakeArgs` / `EvaluateDisplayY` / `GetScanProgress`)

Notes, hold bodies, and the scanner still go through `PositionFunction.EvaluateDisplayY` and are unaffected. Boundary-touch animations (BoundaryBound) keep their existing trigger logic.

## Verification

- Repo-wide grep: zero remaining references to `GetPageBoundaryScreenY` / `GetVisibleBand`
- Diff verified line-identical to upstream (modulo path prefix `engines/unity/`)
- With default args (a=1, b=0), boundary positions are bit-identical to main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved play-area boundary positioning for more consistent note rendering.
  * Ensured boundaries remain stable across pages and are not affected by page-specific position bands.

* **Refactor**
  * Simplified boundary calculations by removing outdated page-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->