### PR TITLE
fix(gameplay): apply DragCoHit subsequent-note gate to DropDrag

### DIFF
--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -284,7 +284,7 @@ public class InputController : MonoBehaviour
                 if (FlickingNotes.ContainsKey(finger.Index) || FlickingNotes.ContainsValue(flickNote))
                     continue;
                 if (flickNote.IsFlicking) continue;
-                if (!IsEligibleSelectAfterDrag(flickNote, acceptedDrag)) continue;
+                if (!IsEligibleSelectAfterDrag(flickNote, acceptedDrag, pressedPosition)) continue;
                 hitCandidates.Add(flickNote);
                 continue;
             }
@@ -293,12 +293,12 @@ public class InputController : MonoBehaviour
             {
                 // Lists are per-frame snapshots; same-frame multi-finger rebind uses Update.
                 if (holdNote.IsHolding || HoldingNotes.ContainsKey(finger.Index)) continue;
-                if (!IsEligibleSelectAfterDrag(holdNote, acceptedDrag)) continue;
+                if (!IsEligibleSelectAfterDrag(holdNote, acceptedDrag, pressedPosition)) continue;
                 hitCandidates.Add(holdNote);
                 continue;
             }
 
-            if (!IsEligibleSelectAfterDrag(note, acceptedDrag)) continue;
+            if (!IsEligibleSelectAfterDrag(note, acceptedDrag, pressedPosition)) continue;
             hitCandidates.Add(note);
         }
 
@@ -316,13 +316,20 @@ public class InputController : MonoBehaviour
     /// Same-Down select gate after an optional accepted Drag.
     /// Blocks only when select is more than <see cref="DragCoHitWindowSeconds"/> later
     /// than the Drag (<c>effectiveNoteTime</c>). Also keeps cross-page early suppress.
+    /// If no colliding Drag was accepted, an earlier DropDrag whose landing this tap
+    /// still occupies (later note's radius) uses the same 30ms window — DropDrag's
+    /// own hitbox is smaller than DropClick and often misses the shared landing.
     /// </summary>
-    private bool IsEligibleSelectAfterDrag(Note note, Note acceptedDrag)
+    private bool IsEligibleSelectAfterDrag(Note note, Note acceptedDrag, Vector2 tap)
     {
         if (acceptedDrag != null)
         {
             var delta = EffectiveNoteTime(note) - EffectiveNoteTime(acceptedDrag);
             if (delta > DragCoHitWindowSeconds) return false;
+        }
+        else if (IsOccludedByDropDrag(note, tap))
+        {
+            return false;
         }
 
         if (note.Model.page_index > game.Chart.CurrentPageId &&
@@ -333,6 +340,33 @@ public class InputController : MonoBehaviour
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// DropDrag stand-in for DragCoHit when the DropDrag collider itself missed.
+    /// Only DropDrag gates (same role as DragHead/Child); only live, hittable
+    /// or already-armed notes. Armed notes stay eligible to shield until they clear.
+    /// </summary>
+    private bool IsOccludedByDropDrag(Note select, Vector2 tap)
+    {
+        foreach (var id in game.SpawnedNotes.Keys)
+        {
+            var drag = game.SpawnedNotes[id];
+            if (drag == null || drag == select) continue;
+            if (drag.IsCollected || drag.IsCleared) continue;
+            if (!drag.HasEmerged || drag.Type != NoteType.DropDrag) continue;
+            if (EffectiveNoteTime(drag) >= EffectiveNoteTime(select)) continue;
+            if (!drag.IsArmed)
+            {
+                if (!IsTouchableNote(drag) || !drag.CanHandleTouch()) continue;
+                var grade = drag.GetTouchGrade();
+                if (grade == NoteGrade.None || grade == NoteGrade.Miss) continue;
+            }
+
+            if (DropNoteIsolation.OccludesSelect(drag, select, tap)) return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -317,8 +317,9 @@ public class InputController : MonoBehaviour
     /// Blocks only when select is more than <see cref="DragCoHitWindowSeconds"/> later
     /// than the Drag (<c>effectiveNoteTime</c>). Also keeps cross-page early suppress.
     /// If no colliding Drag was accepted, an earlier DropDrag whose landing this tap
-    /// still occupies (later note's radius) uses the same 30ms window — DropDrag's
-    /// own hitbox is smaller than DropClick and often misses the shared landing.
+    /// still occupies (later note's radius) uses the same 30ms window and is queued
+    /// into <see cref="dragBatchScratch"/> so the tap is attributed to DropDrag.
+    /// DropDrag's own hitbox is unchanged.
     /// </summary>
     private bool IsEligibleSelectAfterDrag(Note note, Note acceptedDrag, Vector2 tap)
     {
@@ -344,8 +345,12 @@ public class InputController : MonoBehaviour
 
     /// <summary>
     /// DropDrag stand-in for DragCoHit when the DropDrag collider itself missed.
-    /// Only DropDrag gates (same role as DragHead/Child); only live, hittable
-    /// or already-armed notes. Armed notes stay eligible to shield until they clear.
+    /// Only live hittable DropDrag notes gate (same role as DragHead/Child).
+    /// The matching DropDrag is queued into <see cref="dragBatchScratch"/> so
+    /// <see cref="SettleDragBatch"/> still attributes this Down — denying the
+    /// later Select without settling DropDrag would leave a dead zone between
+    /// DropDrag and DropClick radii. Armed notes do not shield later Downs
+    /// (same as DragHead once it leaves <see cref="TouchableDragNotes"/>).
     /// </summary>
     private bool IsOccludedByDropDrag(Note select, Vector2 tap)
     {
@@ -356,14 +361,14 @@ public class InputController : MonoBehaviour
             if (drag.IsCollected || drag.IsCleared) continue;
             if (!drag.HasEmerged || drag.Type != NoteType.DropDrag) continue;
             if (EffectiveNoteTime(drag) >= EffectiveNoteTime(select)) continue;
-            if (!drag.IsArmed)
-            {
-                if (!IsTouchableNote(drag) || !drag.CanHandleTouch()) continue;
-                var grade = drag.GetTouchGrade();
-                if (grade == NoteGrade.None || grade == NoteGrade.Miss) continue;
-            }
+            if (!IsTouchableNote(drag) || !drag.CanHandleTouch()) continue;
+            var grade = drag.GetTouchGrade();
+            if (grade == NoteGrade.None || grade == NoteGrade.Miss) continue;
+            if (!DropNoteIsolation.OccludesSelect(drag, select, tap)) continue;
 
-            if (DropNoteIsolation.OccludesSelect(drag, select, tap)) return true;
+            if (!dragBatchScratch.Contains(drag))
+                dragBatchScratch.Add(drag);
+            return true;
         }
 
         return false;

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -165,6 +165,10 @@ public class InputController : MonoBehaviour
             // depends on whether a higher-priority Select candidate claims this fresh Down.
             // Misses still settle immediately and do not arm DragCoHit.
             var acceptedDrag = CollectCollidingDragBatch(pressedPosition);
+            // Collider miss: collect occluding DropDrags first so every Select on this
+            // Down shares one DragCoHit representative (and one batch window).
+            if (acceptedDrag == null)
+                acceptedDrag = CollectOccludingDropDragBatch(finger, pressedPosition);
 
             // Select is still gated by the accepted Drag before either candidate settles,
             // preserving DragCoHit and cross-page suppression without changing event order.
@@ -284,7 +288,7 @@ public class InputController : MonoBehaviour
                 if (FlickingNotes.ContainsKey(finger.Index) || FlickingNotes.ContainsValue(flickNote))
                     continue;
                 if (flickNote.IsFlicking) continue;
-                if (!IsEligibleSelectAfterDrag(flickNote, acceptedDrag, pressedPosition)) continue;
+                if (!IsEligibleSelectAfterDrag(flickNote, acceptedDrag)) continue;
                 hitCandidates.Add(flickNote);
                 continue;
             }
@@ -293,12 +297,12 @@ public class InputController : MonoBehaviour
             {
                 // Lists are per-frame snapshots; same-frame multi-finger rebind uses Update.
                 if (holdNote.IsHolding || HoldingNotes.ContainsKey(finger.Index)) continue;
-                if (!IsEligibleSelectAfterDrag(holdNote, acceptedDrag, pressedPosition)) continue;
+                if (!IsEligibleSelectAfterDrag(holdNote, acceptedDrag)) continue;
                 hitCandidates.Add(holdNote);
                 continue;
             }
 
-            if (!IsEligibleSelectAfterDrag(note, acceptedDrag, pressedPosition)) continue;
+            if (!IsEligibleSelectAfterDrag(note, acceptedDrag)) continue;
             hitCandidates.Add(note);
         }
 
@@ -316,21 +320,13 @@ public class InputController : MonoBehaviour
     /// Same-Down select gate after an optional accepted Drag.
     /// Blocks only when select is more than <see cref="DragCoHitWindowSeconds"/> later
     /// than the Drag (<c>effectiveNoteTime</c>). Also keeps cross-page early suppress.
-    /// If no colliding Drag was accepted, an earlier DropDrag whose landing this tap
-    /// still occupies (later note's radius) uses the same 30ms window and is queued
-    /// into <see cref="dragBatchScratch"/> so the tap is attributed to DropDrag.
-    /// DropDrag's own hitbox is unchanged.
     /// </summary>
-    private bool IsEligibleSelectAfterDrag(Note note, Note acceptedDrag, Vector2 tap)
+    private bool IsEligibleSelectAfterDrag(Note note, Note acceptedDrag)
     {
         if (acceptedDrag != null)
         {
             var delta = EffectiveNoteTime(note) - EffectiveNoteTime(acceptedDrag);
             if (delta > DragCoHitWindowSeconds) return false;
-        }
-        else if (IsOccludedByDropDrag(note, tap))
-        {
-            return false;
         }
 
         if (note.Model.page_index > game.Chart.CurrentPageId &&
@@ -344,34 +340,69 @@ public class InputController : MonoBehaviour
     }
 
     /// <summary>
-    /// DropDrag stand-in for DragCoHit when the DropDrag collider itself missed.
-    /// Only live hittable DropDrag notes gate (same role as DragHead/Child).
-    /// The matching DropDrag is queued into <see cref="dragBatchScratch"/> so
-    /// <see cref="SettleDragBatch"/> still attributes this Down — denying the
-    /// later Select without settling DropDrag would leave a dead zone between
-    /// DropDrag and DropClick radii. Armed notes do not shield later Downs
-    /// (same as DragHead once it leaves <see cref="TouchableDragNotes"/>).
+    /// DropDrag stand-in when the collider missed. Queues every occluding DropDrag
+    /// within <see cref="DragStackBatchGapSeconds"/> of the first match (same window
+    /// as <see cref="CollectCollidingDragBatch"/>) and returns that representative
+    /// so all Selects on this Down share one DragCoHit gate.
     /// </summary>
-    private bool IsOccludedByDropDrag(Note select, Vector2 tap)
+    private Note CollectOccludingDropDragBatch(GameFinger finger, Vector2 tap)
     {
-        foreach (var id in game.SpawnedNotes.Keys)
+        Note accepted = null;
+        var acceptedTime = 0f;
+        foreach (var drag in TouchableDragNotes)
         {
-            var drag = game.SpawnedNotes[id];
-            if (drag == null || drag == select) continue;
-            if (drag.IsCollected || drag.IsCleared) continue;
-            if (!drag.HasEmerged || drag.Type != NoteType.DropDrag) continue;
-            if (EffectiveNoteTime(drag) >= EffectiveNoteTime(select)) continue;
+            if (drag.Type != NoteType.DropDrag) continue;
             if (!IsTouchableNote(drag) || !drag.CanHandleTouch()) continue;
             var grade = drag.GetTouchGrade();
             if (grade == NoteGrade.None || grade == NoteGrade.Miss) continue;
-            if (!DropNoteIsolation.OccludesSelect(drag, select, tap)) continue;
+            if (!OccludesAnyCollidingSelect(drag, finger, tap)) continue;
 
-            if (!dragBatchScratch.Contains(drag))
+            if (accepted == null)
+            {
+                accepted = drag;
+                acceptedTime = EffectiveNoteTime(drag);
                 dragBatchScratch.Add(drag);
-            return true;
+                continue;
+            }
+
+            if (Math.Abs(EffectiveNoteTime(drag) - acceptedTime) > DragStackBatchGapSeconds)
+                continue;
+
+            dragBatchScratch.Add(drag);
+        }
+
+        return accepted;
+    }
+
+    private bool OccludesAnyCollidingSelect(Note drag, GameFinger finger, Vector2 tap)
+    {
+        foreach (var select in TouchableSelectNotes)
+        {
+            if (!IsCollidingSelectCandidate(select, finger, tap)) continue;
+            if (DropNoteIsolation.OccludesSelect(drag, select, tap)) return true;
         }
 
         return false;
+    }
+
+    private bool IsCollidingSelectCandidate(Note note, GameFinger finger, Vector2 tap)
+    {
+        if (!IsTouchableNote(note)) return false;
+        if (!note.DoesCollide(tap)) return false;
+
+        if (note is FlickNote flickNote)
+        {
+            if (FlickingNotes.ContainsKey(finger.Index) || FlickingNotes.ContainsValue(flickNote))
+                return false;
+            if (flickNote.IsFlicking) return false;
+        }
+
+        if (note is HoldNote holdNote)
+        {
+            if (holdNote.IsHolding || HoldingNotes.ContainsKey(finger.Index)) return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 // Landing colliders sit on the scanline while sprites fall in, so a later Select can
 // overlap this tap even when DropDrag's own smaller hitbox missed. The spatial test
 // uses the later note's radius around DropDrag's landing; the time test is
-// InputController.DragCoHitWindowSeconds.
+// InputController.DragCoHitWindowSeconds. InputController also queues that DropDrag
+// into the settle batch so the tap is attributed to it (hitbox size unchanged).
 internal static class DropNoteIsolation
 {
     public static float WorldHitboxRadius(Note note)

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+// DropDrag uses the same 30ms subsequent-note gate as DragHead/Child (DragCoHit).
+// Landing colliders sit on the scanline while sprites fall in, so a later Select can
+// overlap this tap even when DropDrag's own smaller hitbox missed. The spatial test
+// uses the later note's radius around DropDrag's landing; the time test is
+// InputController.DragCoHitWindowSeconds.
+internal static class DropNoteIsolation
+{
+    public static float WorldHitboxRadius(Note note)
+    {
+        if (note == null) return 0f;
+        var collider = note.Renderer != null ? note.Renderer.GetCollider() : null;
+        if (collider == null) return 0f;
+        var scale = Mathf.Abs(note.transform.lossyScale.x);
+        if (scale <= 0f || !float.IsFinite(scale)) return 0f;
+        var radius = collider.radius * scale;
+        return float.IsFinite(radius) ? radius : 0f;
+    }
+
+    /// <summary>
+    /// True when <paramref name="later"/> is more than
+    /// <see cref="InputController.DragCoHitWindowSeconds"/> after this DropDrag and the
+    /// tap still sits on the DropDrag landing (later note's radius).
+    /// </summary>
+    public static bool OccludesSelect(Note dropDrag, Note later, Vector2 tap)
+    {
+        if (dropDrag == null || later == null) return false;
+        if (dropDrag.Type != NoteType.DropDrag) return false;
+
+        var gap = (later.Model.start_time + later.JudgmentOffset)
+                  - (dropDrag.Model.start_time + dropDrag.JudgmentOffset);
+        if (gap <= InputController.DragCoHitWindowSeconds) return false;
+
+        var laterRadius = WorldHitboxRadius(later);
+        if (laterRadius <= 0f || !float.IsFinite(laterRadius)) return false;
+
+        Vector2 landing = dropDrag.transform.position;
+        return (tap - landing).sqrMagnitude <= laterRadius * laterRadius;
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs
@@ -4,8 +4,9 @@ using UnityEngine;
 // Landing colliders sit on the scanline while sprites fall in, so a later Select can
 // overlap this tap even when DropDrag's own smaller hitbox missed. The spatial test
 // uses the later note's radius around DropDrag's landing; the time test is
-// InputController.DragCoHitWindowSeconds. InputController also queues that DropDrag
-// into the settle batch so the tap is attributed to it (hitbox size unchanged).
+// InputController.DragCoHitWindowSeconds. InputController collects occluding
+// DropDrags (same-tick stack within DragStackBatchGapSeconds) before choosing
+// Select, then gates every candidate with that representative.
 internal static class DropNoteIsolation
 {
     public static float WorldHitboxRadius(Note note)

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteIsolation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c4e9b2a1d8f46c0a3e5f917b6c82d04


### PR DESCRIPTION
## Summary
- DropDrag landing colliders sit on the scanline and are smaller than DropClick, so a tap meant for DropDrag could accept a later Select on the same Down.
- When no colliding drag was accepted, an earlier live DropDrag whose landing this tap still occupies (later note's radius) now uses the same 30ms DragCoHit window.
- Same-tick / `<= 30ms` stacks still co-clear. DropDrag's own hitbox is unchanged.

## Test plan
- [ ] Tap a DropDrag with a later DropClick on the same landing (about 50-200ms later): the DropClick must not clear
- [ ] Same-tick or `<= 30ms` DropDrag+DropClick stack: both still co-clear
- [ ] Regular DragHead/Child + Click co-hit and subsequent-note blocking unchanged
- [ ] Confirm DropDrag collider size is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tap selection after drag actions for more accurate note targeting.
  * Prevented taps from selecting notes visually occluded by recently dropped notes.
  * Improved handling of note size and placement when determining whether a selection is blocked.
  * Ensured dropped notes are correctly attributed when they block a subsequent selection.
  * Improved selection behavior for stacked or closely timed dropped notes during gameplay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->