### PR TITLE
fix(storyboard): parse pivot_x/pivot_y from storyboard.json

### DIFF
--- a/engines/unity/Assets/Scripts/Storyboard/GenericStateParser.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/GenericStateParser.cs
@@ -61,6 +61,9 @@ namespace Cytoid.Storyboard
             state.RotY = (float?) json.SelectToken("rot_y") ?? state.RotY;
             state.RotZ = (float?) json.SelectToken("rot_z") ?? state.RotZ;
 
+            state.PivotX = (float?) json.SelectToken("pivot_x") ?? state.PivotX;
+            state.PivotY = (float?) json.SelectToken("pivot_y") ?? state.PivotY;
+
             state.ScaleX = (float?) json.SelectToken("scale_x") ?? state.ScaleX;
             state.ScaleY = (float?) json.SelectToken("scale_y") ?? state.ScaleY;
             if (json["scale"] != null)


### PR DESCRIPTION
## Summary
- Author `storyboard.json` never read `pivot_x` / `pivot_y` in `ParseStageObjectState`, so sprite/text/video easers kept the default `RectTransform` pivot `(0.5, 0.5)`.
- Compiled storyboards already populate `StageObjectState.PivotX` / `PivotY` via `ToObject`. This matches the existing `rot_x` / `scale_x` snake_case keys.

Fixes #209.

## Test plan
- [ ] Uncompiled sprite with `pivot_x: 0` and `rot_z`: rotation should pivot on the left edge, not the center
- [ ] Uncompiled text/video with `pivot_y: 1` behaves the same as a compiled storyboard that already set `PivotY`
- [ ] States that omit `pivot_*` keep the previous/template pivot (or the default if unset)
- [ ] Compiled `storyboard.json` path unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading optional horizontal and vertical pivot values when parsing stage object states.
  * Existing pivot values are preserved when these values are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->