### PR TITLE
fix(gameplay): point hold lines along PositionFunction travel

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
@@ -26,6 +26,16 @@ public static class PositionFunction
     }
 
     /// <summary>
+    /// Sign of display-Y travel as time moves forward (+1 up, -1 down).
+    /// Negative <c>a</c> reverses the page, so this is scan × sign(a).
+    /// </summary>
+    public static int ChronologicalTravelSign(ChartModel.Page page)
+    {
+        var signA = page.position_arg_a < 0f ? -1 : 1;
+        return page.scan_line_direction * signA;
+    }
+
+    /// <summary>
     /// Normalized play-area Y in [-1, 1] (bottom = -1).
     /// </summary>
     public static float EvaluateDisplayY(ChartModel.Page page, float chronologicalT)

--- a/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicHoldNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicHoldNoteRenderer.cs
@@ -115,7 +115,8 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
             }
             if (!Note.IsCleared)
             {
-                Line.flipY = Note.Model.direction == -1;
+                var page = Game.Chart.Model.page_list[Note.Model.page_index];
+                Line.flipY = PositionFunction.ChronologicalTravelSign(page) < 0;
                 CompletedLine.flipY = Line.flipY;
                 CompletedLine.color = Fill.color;
                 var ringSortingOrder = Ring.sortingOrder;


### PR DESCRIPTION
﻿## Summary
- Hold body `flipY` used `scan_line_direction` only. C2 pages with negative PositionFunction `a` reverse the page, so holds that travel up (e.g. IRON 1307–1314) rendered downward on every other page.
- `flipY` now follows chronological display-Y travel: `scan × sign(a)`. Default pages (`a = 1`) are unchanged.

## Test plan
- [ ] IRON notes 1307–1314: all hold lines point up
- [ ] A chart with only `a = 1, b = 0` pages: hold direction still matches scan (up on +1, down on -1)
- [ ] Long hold still uses the same `Line.flipY` (no separate path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hold note rendering now flips vertically according to the chart page’s chronological travel direction.
  - Notes with reversed positioning values display with the correct orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->