### PR TITLE
fix(gameplay): do not stack drag children touched by a NoteController

### DIFF
--- a/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs
+++ b/engines/unity/Assets/Editor/Tests/DragStackPlannerTests.cs
@@ -100,7 +100,7 @@ public class DragStackPlannerTests
     }
 
     [Test]
-    public void IdenticalStoryboardSignaturesStillStack()
+    public void IdenticalNoteControllersDoNotStack()
     {
         var model = Model(
             Child(1, 0.5, 1f),
@@ -113,6 +113,24 @@ public class DragStackPlannerTests
 
         var plan = DragStackPlanner.Build(model, signatures);
 
+        Assert.That(plan.NoteIdToStackId, Is.Empty);
+    }
+
+    [Test]
+    public void UncontrolledPairStillStacksBesideAControlledNote()
+    {
+        var model = Model(
+            Child(1, 0.5, 1f),
+            Child(2, 0.5, 1f),
+            Child(3, 0.5, 1f));
+        var signatures = new Dictionary<int, string>
+        {
+            {3, "dx=0.1"}
+        };
+
+        var plan = DragStackPlanner.Build(model, signatures);
+
+        Assert.That(plan.NoteIdToStackId.ContainsKey(3), Is.False);
         Assert.That(plan.NoteIdToStackId[1], Is.EqualTo(plan.NoteIdToStackId[2]));
     }
 

--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -273,6 +273,7 @@ public class Chart
     /// Groups co-located drag children after storyboard parse. Call once from
     /// <see cref="Game.Initialize"/> so note-controller signatures are already resolved.
     /// Charts without storyboard pass a null signature map (uncontrolled notes only).
+    /// Notes touched by a NoteController stay on the per-note path; ids are unchanged.
     /// </summary>
     public void ApplyDragStacks(IReadOnlyDictionary<int, string> storyboardSignatures = null)
     {

--- a/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/DragStackPlanner.cs
@@ -12,10 +12,9 @@ using Cytoid.Storyboard;
 /// Heads travel along their own chain and cannot share a host.</item>
 /// <item>Full visual/collision equivalence: type, start time, intro time, chart x, approach rate,
 /// size, opacity, hitbox, colors, style, page index, scan direction, and is_forward.</item>
-/// <item>Storyboard note-controller signature matches. Signatures are computed from
-/// the parsed storyboard so selector expansion and <c>$note</c> substitution are
-/// already resolved. Empty signature = uncontrolled. Trigger-spawned controllers
-/// (unknown timeline until fire) force a unique per-note signature so they never merge.</item>
+/// <item>No storyboard note controller. A non-empty signature (parsed controller,
+/// including trigger-spawned) keeps the per-note path so a later destroy/spawn
+/// cannot desync a shared host. Chart ids are unchanged either way.</item>
 /// <item>Outgoing chain destinations match: every member has no next, or every next
 /// note shares the same visual/storyboard key. Origins whose next notes diverge
 /// stay independent so shared rotation cannot point a line at the wrong child.</item>
@@ -60,6 +59,10 @@ public static class DragStackPlanner
             {
                 signature = UncontrolledSignature;
             }
+
+            // Any NoteController contact opts out. Identical controllers used to stack;
+            // a later trigger destroy of one controller would freeze the primary.
+            if (signature != UncontrolledSignature) continue;
 
             var key = EquivalenceKey.From(note, signature);
             if (!buckets.TryGetValue(key, out var list))


### PR DESCRIPTION
## Summary
- Drag-child stacks skip any note that has a storyboard NoteController (including identical copies and trigger-spawned controllers).
- Uncontrolled co-located children still share a host. Chart note ids are unchanged.
- Closes the post-#201 gap where a later trigger destroy of one matching controller could freeze the stack primary.

## Test plan
- [ ] Dense uncontrolled drag stack (no note_controllers): still shares host/lines
- [ ] Same-position children with identical `dx` NoteControllers: each keeps its own GO
- [ ] One controlled child beside two uncontrolled copies: only the uncontrolled pair stacks
- [ ] Failed/missing storyboard: stacking unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notes touched by a storyboard note controller are no longer combined into shared drag stacks.
  * Uncontrolled notes continue to share stacks when eligible, even alongside controlled notes.
  * Note IDs remain unchanged when drag-stack sharing is not applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->